### PR TITLE
Remove cart clean up logic from MongoDriver

### DIFF
--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -528,14 +528,11 @@ export class MongoDriver implements DataStore {
    * @param {LearningObjectID} id which document to delete
    */
   async deleteLearningObject(id: string): Promise<void> {
-    // remove object from all carts first
     try {
-      await this.cleanObjectsFromCarts([id]);
-    } catch (error) {
-      console.log(error);
+      return await this.remove(COLLECTIONS.LearningObject, id);
+    } catch (e) {
+      return Promise.reject(e);
     }
-    // now remove from database
-    return this.remove(COLLECTIONS.LearningObject, id);
   }
 
   /**
@@ -545,31 +542,11 @@ export class MongoDriver implements DataStore {
    * @param {LearningObjectID} id which document to delete
    */
   async deleteMultipleLearningObjects(ids: string[]): Promise<any> {
-    // remove objects from all carts first
-    try {
-      await this.cleanObjectsFromCarts(ids);
-    } catch (error) {
-      console.log(error);
-    }
-
     // now remove objects from database
     return Promise.all(
       ids.map(id => {
         return this.remove(COLLECTIONS.LearningObject, id);
       }),
-    );
-  }
-
-  /**
-   * Removes learning object ids from all carts that reference them
-   * @param ids Array of string ids
-   */
-  async cleanObjectsFromCarts(ids: Array<string>): Promise<void> {
-    return request.patch(
-      process.env.CART_API +
-        '/libraries/learning-objects/' +
-        ids.join(',') +
-        '/clean',
     );
   }
 

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -6,7 +6,7 @@ import * as striptags from 'striptags';
 import * as stemmer from 'stemmer';
 import { LearningObjectQuery } from '../interfaces/DataStore';
 import { Metrics } from '@cyber4all/clark-entity/dist/learning-object';
-import { CartInteractor } from './CartInteractor';
+import { LibraryInteractor } from './LibraryInteractor';
 import { File } from '@cyber4all/clark-entity/dist/learning-object';
 export type LearningObjectFile = File;
 export type GradientVector = [number, number, number, number];
@@ -432,6 +432,8 @@ export class LearningObjectInteractor {
         const path = `${learningObjectID}/${username}/`;
         await fileManager.deleteAll(path);
       }
+      LibraryInteractor.cleanObjectsFromLibraries([learningObjectID]);
+      return Promise.resolve();
     } catch (error) {
       return Promise.reject(
         `Problem deleting Learning Object. Error: ${error}`,
@@ -463,6 +465,7 @@ export class LearningObjectInteractor {
         const path = `${object.id}/${username}/`;
         await fileManager.deleteAll(path);
       }
+      LibraryInteractor.cleanObjectsFromLibraries(learningObjectIDs);
     } catch (error) {
       return Promise.reject(
         `Problem deleting Learning Objects. Error: ${error}`,
@@ -744,7 +747,7 @@ export class LearningObjectInteractor {
    */
   private static async loadMetrics(objectID: string): Promise<Metrics> {
     try {
-      return CartInteractor.getMetrics(objectID);
+      return LibraryInteractor.getMetrics(objectID);
     } catch (e) {
       return Promise.reject(e);
     }

--- a/src/interactors/LibraryInteractor.ts
+++ b/src/interactors/LibraryInteractor.ts
@@ -14,9 +14,10 @@ export class LibraryInteractor {
   };
   public static async getMetrics(objectID: string): Promise<Metrics> {
     try {
-      this.options.uri = LIBRARY_ROUTES.METRICS(objectID);
-      this.options.headers.Authorization = `Bearer ${generateServiceToken()}`;
-      return request(this.options);
+      const options = { ...this.options };
+      options.uri = LIBRARY_ROUTES.METRICS(objectID);
+      options.headers.Authorization = `Bearer ${generateServiceToken()}`;
+      return request(options);
     } catch (e) {
       return Promise.reject(`Problem fetching metrics. Error: ${e}`);
     }
@@ -29,9 +30,10 @@ export class LibraryInteractor {
   public static async cleanObjectsFromLibraries(
     ids: Array<string>,
   ): Promise<void> {
-    this.options.uri = LIBRARY_ROUTES.CLEAN(ids);
-    this.options.method = 'PATCH';
-    this.options.headers.Authorization = `Bearer ${generateServiceToken()}`;
-    return request(this.options);
+    const options = { ...this.options };
+    options.uri = LIBRARY_ROUTES.CLEAN(ids);
+    options.method = 'PATCH';
+    options.headers.Authorization = `Bearer ${generateServiceToken()}`;
+    return request(options);
   }
 }

--- a/src/interactors/LibraryInteractor.ts
+++ b/src/interactors/LibraryInteractor.ts
@@ -1,23 +1,37 @@
 import * as request from 'request-promise';
-import { CART_ROUTES } from '../routes';
+import { LIBRARY_ROUTES } from '../routes';
 import { Metrics } from '@cyber4all/clark-entity/dist/learning-object';
 import { generateServiceToken } from '../drivers/TokenManager';
 
-export class CartInteractor {
+export class LibraryInteractor {
   private static options = {
     uri: '',
     json: true,
     headers: {
       Authorization: 'Bearer',
     },
+    method: 'GET',
   };
   public static async getMetrics(objectID: string): Promise<Metrics> {
     try {
-      this.options.uri = CART_ROUTES.METRICS(objectID);
+      this.options.uri = LIBRARY_ROUTES.METRICS(objectID);
       this.options.headers.Authorization = `Bearer ${generateServiceToken()}`;
       return request(this.options);
     } catch (e) {
       return Promise.reject(`Problem fetching metrics. Error: ${e}`);
     }
+  }
+
+  /**
+   * Removes learning object ids from all carts that reference them
+   * @param ids Array of string ids
+   */
+  public static async cleanObjectsFromLibraries(
+    ids: Array<string>,
+  ): Promise<void> {
+    this.options.uri = LIBRARY_ROUTES.CLEAN(ids);
+    this.options.method = 'PATCH';
+    this.options.headers.Authorization = `Bearer ${generateServiceToken()}`;
+    return request(this.options);
   }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,8 +1,13 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-export const CART_ROUTES = {
+export const LIBRARY_ROUTES = {
   METRICS(objectID: string) {
     return `${process.env.CART_API}/learning-objects/${objectID}/metrics`;
+  },
+  CLEAN(objectIDs: string[]) {
+    return `${process.env.CART_API}/libraries/learning-objects/${objectIDs.join(
+      ',',
+    )}/clean`;
   },
 };


### PR DESCRIPTION
Remove cart clean up logic from MongoDriver and into LearningObject interactor.
MongoDriver should not make requests to external services.