### PR TITLE
Fix issue with missing file metadata 

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/express-jwt": "0.0.40",
     "@types/jest": "^23.1.5",
     "@types/jsonwebtoken": "^7.2.5",
-    "@types/mongodb": "^3.1.1",
+    "@types/mongodb": "^3.1.7",
     "@types/morgan": "^1.7.35",
     "@types/multer": "^1.3.6",
     "@types/oboe": "^2.0.28",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dotenv": "^6.0.0",
     "express": "^4.16.2",
     "express-jwt": "^5.3.0",
-    "mongodb": "2.2.31",
+    "mongodb": "^3.1.4",
     "morgan": "^1.9.0",
     "multer": "^1.3.0",
     "pdfkit": "^0.8.3",

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -117,6 +117,7 @@ COLLECTIONS_MAP.set(
 );
 
 export class MongoDriver implements DataStore {
+  private mongoClient: MongoClient;
   private db: Db;
 
   constructor(dburi: string) {
@@ -139,7 +140,8 @@ export class MongoDriver implements DataStore {
    */
   async connect(dbURI: string, retryAttempt?: number): Promise<void> {
     try {
-      this.db = await MongoClient.connect(dbURI);
+      this.mongoClient = await MongoClient.connect(dbURI);
+      this.db = this.mongoClient.db();
     } catch (e) {
       if (!retryAttempt) {
         this.connect(
@@ -159,7 +161,7 @@ export class MongoDriver implements DataStore {
    * important or if you are sure that *everything* is finished.
    */
   disconnect(): void {
-    this.db.close();
+    this.mongoClient.close();
   }
   /////////////
   // INSERTS //

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -28,6 +28,7 @@ import {
   MultipartFileUploadStatusUpdates,
   CompletedPart,
 } from '../interfaces/FileManager';
+import { LearningObjectFile } from '../interactors/LearningObjectInteractor';
 
 dotenv.config();
 
@@ -194,6 +195,43 @@ export class MongoDriver implements DataStore {
         object.outcomes,
       );
       return id;
+    } catch (e) {
+      return Promise.reject(e);
+    }
+  }
+
+  /**
+   * Updates or inserts LearningObjectFile into learning object's files array
+   *
+   * @param {{
+   *     id: string;
+   *     loFile: LearningObjectFile;
+   *   }} params
+   * @returns {Promise<void>}
+   * @memberof MongoDriver
+   */
+  public async addToFiles(params: {
+    id: string;
+    loFile: LearningObjectFile;
+  }): Promise<void> {
+    try {
+      const existingDoc = await this.db
+        .collection(COLLECTIONS.LearningObject.name)
+        .findOneAndUpdate(
+          { _id: params.id, 'materials.files.url': params.loFile.url },
+          { $set: { 'materials.files.$[element]': params.loFile } },
+          // @ts-ignore: arrayFilters is in fact a property defined by documentation. Property does not exist in type definition.
+          { arrayFilters: [{ 'element.url': params.loFile.url }] },
+        );
+      if (!existingDoc.value) {
+        await this.db.collection(COLLECTIONS.LearningObject.name).updateOne(
+          {
+            _id: params.id,
+          },
+          { $push: { 'materials.files': params.loFile } },
+        );
+      }
+      return Promise.resolve();
     } catch (e) {
       return Promise.reject(e);
     }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -413,7 +413,7 @@ export class LearningObjectInteractor {
   }
 
   /**
-   * Updates or inserts metadata for file as LearningObjectFile
+   * Inserts metadata for file as LearningObjectFile
    *
    * @private
    * @static
@@ -431,28 +431,10 @@ export class LearningObjectInteractor {
     loFile: LearningObjectFile;
   }): Promise<void> {
     try {
-      const learningObject = await params.dataStore.fetchLearningObject(
-        params.id,
-        true,
-        true,
-      );
-      let found = false;
-      for (let i = 0; i < learningObject.materials.files.length; i++) {
-        const oldFile = learningObject.materials.files[i];
-        if (params.loFile.url === oldFile.url) {
-          found = true;
-          params.loFile.description = oldFile.description;
-          learningObject.materials.files[i] = params.loFile;
-          break;
-        }
-      }
-      if (!found) {
-        learningObject.materials.files.push(params.loFile);
-      }
-      return await params.dataStore.editLearningObject(
-        params.id,
-        learningObject,
-      );
+      return await params.dataStore.addToFiles({
+        id: params.id,
+        loFile: params.loFile,
+      });
     } catch (e) {
       return Promise.reject(e);
     }

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -5,6 +5,7 @@ import {
   MultipartFileUploadStatusUpdates,
   CompletedPart,
 } from './FileManager';
+import { LearningObjectFile } from '../interactors/LearningObjectInteractor';
 
 export interface DataStore {
   connect(dburi: string): Promise<void>;
@@ -65,7 +66,7 @@ export interface DataStore {
   findParentObjects(params: {
     query: LearningObjectQuery;
   }): Promise<LearningObject[]>;
-
+  addToFiles(params: { id: string; loFile: LearningObjectFile }): Promise<void>;
   // Multipart Uploads
   insertMultipartUploadStatus(params: {
     status: MultipartFileUploadStatus;


### PR DESCRIPTION
This issue was caused by there being race conditions present when concurrently updating a learning object's document in the database. 

Before, the latest copy of a learning object would be fetched from the database so that the interactor could iterate over the array of files and check if the metadata for the file that was just uploaded already existed. ( In the case of a file being overwritten). If the file's metadata existed, the metadata would be updated, else the file is new and its metadata was added to the array of files. The object was then updated in its entirety. Since the file uploads happen in parallel, there were cases where the version of a learning object loaded was no longer up to date, which resulted in replacing the document with a copy that was inconsistent with the document in the database.

Now, the update to existing file metadata happens in place, on the learning object's document in the database, which eliminates the issue of loading, updating, and replacing an outdated copy of a learning object's document.