### PR TITLE
:bug: Fix incorrect filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -1204,7 +1204,7 @@ export class MongoDriver implements DataStore {
   async findSingleFile(params: {
     learningObjectId: string;
     fileId: string;
-  }): Promise<object> {
+  }): Promise<LearningObjectFile> {
     try {
       const fileMetaData = await this.db
         .collection(COLLECTIONS.LearningObject.name)

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -463,12 +463,16 @@ export class LearningObjectInteractor {
         fileId: params.fileId,
       });
 
-      const url = fileMetaData['url'];
+      const url = fileMetaData.url;
 
       // Make http request using attached url in file metadata, pipe response
       // tslint:disable-next-line:max-line-length
       https.get(url, res => {
-        res.pipe(params.responder.writeStream(params.fileId));
+        res.pipe(
+          params.responder.writeStream(
+            `${fileMetaData.name}.${fileMetaData.extension}`,
+          ),
+        );
       });
     } catch (e) {
       Promise.reject(e);

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -470,7 +470,9 @@ export class LearningObjectInteractor {
       https.get(url, res => {
         res.pipe(
           params.responder.writeStream(
-            `${fileMetaData.name}.${fileMetaData.extension}`,
+            `${fileMetaData.name}.${
+              fileMetaData.extension ? fileMetaData.extension : ''
+            }`,
           ),
         );
       });

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -81,9 +81,9 @@ export interface DataStore {
   }): Promise<void>;
   deleteMultipartUploadStatus(params: { id: string }): Promise<void>;
   findSingleFile(params: {
-    learningObjectId:     string,
-    fileId:             string,
-  }): Promise<object>;
+    learningObjectId: string;
+    fileId: string;
+  }): Promise<LearningObjectFile>;
 }
 
 export { Collection as LearningObjectCollection };


### PR DESCRIPTION
Files downloaded directly from API were improperly name with the file's id instead of their name and extension. Service has been updated to name files with their name and extension concatenated.