### PR TITLE
Fix PDF Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1311,23 +1311,24 @@ export class LearningObjectInteractor {
     });
     this.appendCoverPage(doc, learningObject);
     doc.addPage();
-    // Goals
-    if (learningObject.goals.length) {
-      this.appendGradientHeader({
-        gradientRGB,
-        doc,
-        title: PDFText.DESCRIPTION_TITLE,
-        headerYStart: doc.y - 75,
-        textYStart: doc.y - 70 + 20,
-      });
-      this.appendLearningGoals(doc, learningObject);
-    }
+    // Description TEMP REMOVAL
+    // if (learningObject.goals.length) {
+    //   this.appendGradientHeader({
+    //     gradientRGB,
+    //     doc,
+    //     title: PDFText.DESCRIPTION_TITLE,
+    //     headerYStart: doc.y - 75,
+    //     textYStart: doc.y - 70 + 20,
+    //   });
+    //   this.appendLearningGoals(doc, learningObject);
+    // }
     // Outcomes
     if (learningObject.outcomes.length) {
       this.appendGradientHeader({
         gradientRGB,
         doc,
         title: PDFText.OUTCOMES_TITLE,
+        headerYStart: doc.y - 75,
         textYStart: doc.y - 70 + 20,
       });
       this.appendOutcomes(doc, learningObject);

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1328,6 +1328,7 @@ export class LearningObjectInteractor {
         gradientRGB,
         doc,
         title: PDFText.OUTCOMES_TITLE,
+        textYStart: doc.y - 70 + 20,
       });
       this.appendOutcomes(doc, learningObject);
     }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1687,7 +1687,14 @@ export class LearningObjectInteractor {
     doc.text(PDFText.NOTES_TITLE);
     doc.moveDown(0.5);
     doc.fillColor(PDFColors.TEXT).font(PDFFonts.REGULAR);
-    doc.text(learningObject.materials.notes);
+    // Print lines with individual api calls to avoid malformed
+    const lines = learningObject.materials.notes
+      .split(/\n/g)
+      .filter(line => line);
+    for (const line of lines) {
+      doc.text(line);
+      doc.moveDown(0.5);
+    }
   }
 
   /**

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,7 +4,9 @@ dotenv.config();
 export const LEARNING_OBJECT_ROUTES = {
   GET_FILE(id: string, filename: string) {
     return `${
-      process.env.LEARNING_OBJECT_API
+      process.env.NODE_ENV === 'production'
+        ? process.env.LEARNING_OBJECT_API
+        : process.env.LEARNING_OBJECT_API_DEV
     }/learning-objects/${id}/files/${encodeURIComponent(filename)}`;
   },
 };


### PR DESCRIPTION
**Before**
- Learning objects' Readme PDFs **Description** section printed rich text encoding to the PDF causing PDF format to break.
- Learning objects' Readme PDFs **Notes** would truncate text that had new line characters.

**Fixes**
- **Description** section has been removed from PDF
- **Notes** section splits `notes` by new line character and writes each line to the PDF using one `doc.text` API call per line.