### PR TITLE
Fix object search in admin dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressAdminRouteDriver.ts
+++ b/src/drivers/express/ExpressAdminRouteDriver.ts
@@ -1,19 +1,20 @@
 import { LearningObject } from '@cyber4all/clark-entity';
 import { Router } from 'express';
 import { AdminLearningObjectInteractor } from '../../interactors/interactors';
-import { DataStore, FileManager } from '../../interfaces/interfaces';
+import { DataStore, FileManager, LibraryCommunicator } from '../../interfaces/interfaces';
 // This refers to the package.json that is generated in the dist. See /gulpfile.js for reference.
 // tslint:disable-next-line:no-require-imports
 const version = require('../../../package.json').version;
 
 export class ExpressAdminRouteDriver {
-  constructor(private dataStore: DataStore, private fileManager: FileManager) { }
+  constructor(private dataStore: DataStore, private fileManager: FileManager, private library: LibraryCommunicator) { }
 
   public static buildRouter(
     dataStore: DataStore,
     fileManager: FileManager,
+    library: LibraryCommunicator,
   ): Router {
-    const e = new ExpressAdminRouteDriver(dataStore, fileManager);
+    const e = new ExpressAdminRouteDriver(dataStore, fileManager, library);
     const router: Router = Router();
     e.setRoutes(router);
     return router;
@@ -64,6 +65,7 @@ export class ExpressAdminRouteDriver {
         ) {
           learningObjects = await AdminLearningObjectInteractor.searchObjects(
             this.dataStore,
+            this.library,
             name,
             author,
             length,

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -73,7 +73,7 @@ export class ExpressDriver {
     this.app.use(enforceAdminAccess);
     this.app.use(
       '/admin',
-      ExpressAdminRouteDriver.buildRouter(dataStore, fileManager),
+      ExpressAdminRouteDriver.buildRouter(dataStore, fileManager, library),
     );
 
     /**

--- a/src/interactors/AdminLearningObjectInteractor.ts
+++ b/src/interactors/AdminLearningObjectInteractor.ts
@@ -1,5 +1,5 @@
 import { LearningObjectInteractor } from './interactors';
-import { DataStore, FileManager } from '../interfaces/interfaces';
+import { DataStore, FileManager, LibraryCommunicator } from '../interfaces/interfaces';
 import { LearningObjectLock } from '@cyber4all/clark-entity/dist/learning-object';
 
 export class AdminLearningObjectInteractor {
@@ -41,6 +41,7 @@ export class AdminLearningObjectInteractor {
    */
   public static async searchObjects(
     dataStore: DataStore,
+    library: LibraryCommunicator,
     name: string,
     author: string,
     length: string[],
@@ -54,7 +55,7 @@ export class AdminLearningObjectInteractor {
   ): Promise<any> {
     try {
       const accessUnpublished = true;
-      return await this.learningObjectInteractor.searchObjects(dataStore, {
+      return await this.learningObjectInteractor.searchObjects(dataStore, library, {
           name,
           author,
           collection: undefined,
@@ -68,7 +69,7 @@ export class AdminLearningObjectInteractor {
           sortType,
           currPage: page,
           limit,
-        }
+        },
       );
     } catch (e) {
       return Promise.reject(`Problem searching Learning Objects. Error:${e}`);


### PR DESCRIPTION
LibraryCommunicator was not being properly injected into the admin route handler. 