### PR TITLE
Single download fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/PDFKitDriver.ts
+++ b/src/LearningObjects/PDFKitDriver.ts
@@ -499,7 +499,7 @@ function appendUnpackedFileURLs(params: {
     }
 
     params.doc.font(PDFFonts.REGULAR).fillColor(PDFColors.LINK);
-    const url = LEARNING_OBJECT_ROUTES.GET_FILE(params.id, file.id);
+    const url = LEARNING_OBJECT_ROUTES.GET_FILE(params.id, file.id).trim();
     params.doc.text(`${url}`, params.doc.x, params.doc.y, {
       link: url,
       underline: true,

--- a/src/middleware/whitelist.ts
+++ b/src/middleware/whitelist.ts
@@ -1,4 +1,6 @@
 import fetch from 'node-fetch';
+import * as dotenv from 'dotenv';
+dotenv.config();
 
 export async function enforceWhitelist(username: string) {
   try {

--- a/src/middleware/whitelist.ts
+++ b/src/middleware/whitelist.ts
@@ -1,9 +1,8 @@
 import fetch from 'node-fetch';
-import * as dotenv from 'dotenv';
-dotenv.config();
 
 export async function enforceWhitelist(username: string) {
   try {
+    console.log('whitelisturl: ' + process.env.WHITELISTURL);
     const response = await fetch(process.env.WHITELISTURL);
     const object = await response.json();
     const whitelist: string[] = object.whitelist;
@@ -16,3 +15,5 @@ export async function enforceWhitelist(username: string) {
     throw e;
   }
 }
+
+


### PR DESCRIPTION
The whitelisturl env in production is deformed and node-fetch is reading it as a relative path instead of a full URL. The PR will include a console.log so that we can see exactly what is happening to the string.

This PR also includes the PDF fix for single file downloads