### PR TITLE
Move single file download route to unauthenticated route driver and remove authentication logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.6.7",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressAuthRouteDriver.ts
+++ b/src/drivers/express/ExpressAuthRouteDriver.ts
@@ -256,49 +256,6 @@ export class ExpressAuthRouteDriver {
           res.status(500).send(e);
         }
       });
-
-    router.get(
-      '/users/:username/learning-objects/:loId/files/:fileId/download',
-      async (req, res) => {
-        try {
-          const open = req.query.open;
-          const author: string = req.params.username;
-          const loId: string = req.params.loId;
-          const fileId: string = req.params.fileId;
-          const username = req.user.username;
-          const {
-            filename,
-            mimeType,
-            stream,
-          } = await LearningObjectInteractor.downloadSingleFile({
-            author,
-            username,
-            fileId,
-            dataStore: this.dataStore,
-            fileManager: this.fileManager,
-            learningObjectId: loId,
-          });
-          if (!open) {
-            res.attachment(filename);
-          }
-          res.contentType(mimeType);
-          stream.pipe(res);
-        } catch (e) {
-          if (e.message === 'Invalid Access') {
-            res
-              .status(403)
-              .send(
-                'Invalid Access. You do not have download privileges for this file',
-              );
-          } else {
-            console.error(e);
-            reportError(e);
-            res.status(500).send('Internal Server Error');
-          }
-        }
-      },
-    );
-
     router.delete(
       '/learning-objects/:learningObjectNames/multiple',
       async (req, res) => {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -53,7 +53,7 @@ export class ExpressDriver {
     this.app.use(cookieParser());
 
     // Set our public api routes
-    this.app.use('/', ExpressRouteDriver.buildRouter(dataStore, library));
+    this.app.use('/', ExpressRouteDriver.buildRouter(dataStore, library, fileManager));
 
     // Set Validation Middleware
     this.app.use(enforceTokenAccess);

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -1,18 +1,19 @@
-import { DataStore, LibraryCommunicator } from '../../interfaces/interfaces';
+import { DataStore, LibraryCommunicator, FileManager } from '../../interfaces/interfaces';
 import { Router } from 'express';
 import { LearningObjectInteractor } from '../../interactors/interactors';
 import { LearningObject } from '@cyber4all/clark-entity';
 import * as TokenManager from '../TokenManager';
 import { LearningObjectQuery } from '../../interfaces/DataStore';
+import { reportError } from '../SentryConnector';
 // This refers to the package.json that is generated in the dist. See /gulpfile.js for reference.
 // tslint:disable-next-line:no-require-imports
 const version = require('../../../package.json').version;
 
 export class ExpressRouteDriver {
-  constructor(private dataStore: DataStore, private library: LibraryCommunicator) {}
+  constructor(private dataStore: DataStore, private library: LibraryCommunicator, private fileManager: FileManager) {}
 
-  public static buildRouter(dataStore: DataStore, library: LibraryCommunicator): Router {
-    const e = new ExpressRouteDriver(dataStore, library);
+  public static buildRouter(dataStore: DataStore, library: LibraryCommunicator, fileManager: FileManager): Router {
+    const e = new ExpressRouteDriver(dataStore, library, fileManager);
     const router: Router = Router();
     e.setRoutes(router);
     return router;
@@ -215,5 +216,47 @@ export class ExpressRouteDriver {
         res.status(500).send(e);
       }
     });
+
+    router.get(
+      '/users/:username/learning-objects/:loId/files/:fileId/download',
+      async (req, res) => {
+        try {
+          const open = req.query.open;
+          const author: string = req.params.username;
+          const loId: string = req.params.loId;
+          const fileId: string = req.params.fileId;
+          const username = req.user.username;
+          const {
+            filename,
+            mimeType,
+            stream,
+          } = await LearningObjectInteractor.downloadSingleFile({
+            author,
+            username,
+            fileId,
+            dataStore: this.dataStore,
+            fileManager: this.fileManager,
+            learningObjectId: loId,
+          });
+          if (!open) {
+            res.attachment(filename);
+          }
+          res.contentType(mimeType);
+          stream.pipe(res);
+        } catch (e) {
+          if (e.message === 'Invalid Access') {
+            res
+              .status(403)
+              .send(
+                'Invalid Access. You do not have download privileges for this file',
+              );
+          } else {
+            console.error(e);
+            reportError(e);
+            res.status(500).send('Internal Server Error');
+          }
+        }
+      },
+    );
   }
 }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -397,9 +397,7 @@ export class LearningObjectInteractor {
     username: string;
   }): Promise<{ filename: string; mimeType: string; stream: Readable }> {
     try {
-      const [isWhitelisted, learningObject, fileMetaData] = await Promise.all([
-        // Check if the user is on the whitelist
-        enforceWhitelist(params.username),
+      const [learningObject, fileMetaData] = await Promise.all([
         // Fetch the learning object
         params.dataStore.fetchLearningObject(params.learningObjectId),
         // Collect requested file metadata from datastore
@@ -411,7 +409,6 @@ export class LearningObjectInteractor {
 
       // if the user is not on the whitelist and the LO is not released, throw access error
       if (
-        !isWhitelisted &&
         learningObject.lock &&
         learningObject.lock.restrictions.indexOf(Restriction.DOWNLOAD) !== -1
       ) {


### PR DESCRIPTION
This PR addresses a bug where, when attempting to preview a document using the office live preview URL, the Microsoft API can't access the file due to CLARK's auth check. This PR removes the authentication from the single file download route, making it a public route.