### PR TITLE
remove download restriction check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -406,14 +406,6 @@ export class LearningObjectInteractor {
         }),
       ]);
 
-      // if the user is not on the whitelist and the LO is not released, throw access error
-      if (
-        learningObject.lock &&
-        learningObject.lock.restrictions.indexOf(Restriction.DOWNLOAD) !== -1
-      ) {
-        throw new Error('Invalid Access');
-      }
-
       const path = `${params.author}/${params.learningObjectId}/${
         fileMetaData.fullPath ? fileMetaData.fullPath : fileMetaData.name
       }`;


### PR DESCRIPTION
The route for single file downloads was checking for a "download" restriction on the object. Objects that had the "download" restriction caused the service to throw an "Invalid Access. You do not have download privileges for this file" error. Because the single file download route is now public and we are not checking the whitelist, this check should be removed. 