### PR TITLE
:sparkles: Add route to fetch Learning Object stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectStats/LearningObjectStatStore.ts
+++ b/src/LearningObjectStats/LearningObjectStatStore.ts
@@ -37,10 +37,13 @@ export class LearningObjectStatStore implements LearningObjectStatDatastore {
         course: 0,
       },
     };
-    statsArr.map(stat => {
-      stats.ids.push(...stat.ids);
-      stats.lengths[stat._id] = stat.count;
-    });
+    if (statsArr && statsArr.length) {
+      statsArr.map(stat => {
+        stats.ids.push(...stat.ids);
+        stats.lengths[stat._id] = stat.count;
+      });
+    }
+
     return stats;
   }
 }

--- a/src/LearningObjectStats/LearningObjectStatStore.ts
+++ b/src/LearningObjectStats/LearningObjectStatStore.ts
@@ -1,0 +1,46 @@
+import {
+  LearningObjectStatDatastore,
+  LearningObjectStats,
+} from './LearningObjectStatsInteractor';
+import { Db } from 'mongodb';
+import { COLLECTIONS } from '../drivers/MongoDriver';
+
+export class LearningObjectStatStore implements LearningObjectStatDatastore {
+  constructor(private db: Db) {}
+  async fetchStats(params: {
+    query: any;
+  }): Promise<Partial<LearningObjectStats>> {
+    const statCursor = await this.db
+      .collection(COLLECTIONS.LearningObject.name)
+      .aggregate([
+        { $match: params.query },
+        {
+          $group: {
+            _id: '$length',
+            count: { $sum: 1 },
+            ids: { $push: '$_id' },
+          },
+        },
+      ]);
+    const statsArr: {
+      _id: string;
+      ids: string[];
+      count: number;
+    }[] = await statCursor.toArray();
+    const stats: Partial<LearningObjectStats> = {
+      ids: [],
+      lengths: {
+        nanomodule: 0,
+        micromodule: 0,
+        module: 0,
+        unit: 0,
+        course: 0,
+      },
+    };
+    statsArr.map(stat => {
+      stats.ids.push(...stat.ids);
+      stats.lengths[stat._id] = stat.count;
+    });
+    return stats;
+  }
+}

--- a/src/LearningObjectStats/LearningObjectStatsInteractor.ts
+++ b/src/LearningObjectStats/LearningObjectStatsInteractor.ts
@@ -1,0 +1,36 @@
+import { LibraryCommunicator } from '../interfaces/interfaces';
+
+export interface LearningObjectStats {
+  ids: string[];
+  downloads: number;
+  saves: number;
+  lengths: {
+    nanomodule: number;
+    micromodule: number;
+    module: number;
+    unit: number;
+    course: number;
+  };
+}
+export interface LearningObjectStatDatastore {
+  fetchStats(params: { query: any }): Promise<Partial<LearningObjectStats>>;
+}
+
+export async function getStats(params: {
+  dataStore: LearningObjectStatDatastore;
+  library: LibraryCommunicator;
+  query: any;
+}): Promise<LearningObjectStats> {
+  const stats = await params.dataStore.fetchStats({ query: params.query });
+  stats.downloads = 0;
+  stats.saves = 0;
+  await Promise.all(
+    stats.ids.map(async id => {
+      const metrics = await params.library.getMetrics(id);
+      stats.downloads += metrics.downloads;
+      stats.saves += metrics.saves;
+    }),
+  );
+  delete stats.ids;
+  return stats as LearningObjectStats;
+}

--- a/src/LearningObjectStats/LearningObjectStatsRouteHandler.ts
+++ b/src/LearningObjectStats/LearningObjectStatsRouteHandler.ts
@@ -1,0 +1,37 @@
+import * as LearningObjectStatsInteractor from './LearningObjectStatsInteractor';
+import { Request, Response, Router } from 'express';
+import { DataStore } from '../interfaces/DataStore';
+import { LibraryCommunicator } from '../interfaces/interfaces';
+
+/**
+ * Initializes an express router with endpoints to Create, Update, and Delete
+ * a Learning Object.
+ */
+export function initialize({
+  dataStore,
+  library,
+}: {
+  dataStore: DataStore;
+  library: LibraryCommunicator;
+}) {
+  const router: Router = Router();
+  const getStats = async (req: Request, res: Response) => {
+    try {
+      const query = req.query;
+
+      const stats = await LearningObjectStatsInteractor.getStats({
+        dataStore,
+        library,
+        query,
+      });
+
+      res.status(200).send(stats);
+    } catch (e) {
+      console.error(e);
+      res.status(500).send(e);
+    }
+  };
+
+  router.route('').get(getStats);
+  return router;
+}

--- a/src/LearningObjectStats/LearningObjectStatsRouteHandler.ts
+++ b/src/LearningObjectStats/LearningObjectStatsRouteHandler.ts
@@ -4,8 +4,7 @@ import { DataStore } from '../interfaces/DataStore';
 import { LibraryCommunicator } from '../interfaces/interfaces';
 
 /**
- * Initializes an express router with endpoints to Create, Update, and Delete
- * a Learning Object.
+ * Initializes an express router with endpoints to get stats for Learning Objects
  */
 export function initialize({
   dataStore,

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -32,6 +32,8 @@ import { LearningObjectFile } from '../interactors/LearningObjectInteractor';
 import { reportError } from './SentryConnector';
 import * as ObjectMapper from './Mongo/ObjectMapper';
 import { SubmissionDatastore } from '../LearningObjectSubmission/SubmissionDatastore';
+import { LearningObjectStats } from '../LearningObjectStats/LearningObjectStatsInteractor';
+import { LearningObjectStatStore } from '../LearningObjectStats/LearningObjectStatStore';
 
 export interface Collection {
   name: string;
@@ -120,6 +122,7 @@ COLLECTIONS_MAP.set(
 
 export class MongoDriver implements DataStore {
   submissionStore: SubmissionDatastore;
+  statStore: LearningObjectStatStore;
   togglePublished(
     username: string,
     id: string,
@@ -131,9 +134,10 @@ export class MongoDriver implements DataStore {
   private db: Db;
 
   constructor(dburi: string) {
-    this.connect(dburi).then(
-      () => (this.submissionStore = new SubmissionDatastore(this.db)),
-    );
+    this.connect(dburi).then(() => {
+      this.submissionStore = new SubmissionDatastore(this.db);
+      this.statStore = new LearningObjectStatStore(this.db);
+    });
   }
 
   /**
@@ -503,9 +507,9 @@ export class MongoDriver implements DataStore {
    */
   async mapOutcome(outcome: string, mapping: string): Promise<void> {
     /*
-         * TODO: alter register (and others) to take schema, not collection
-         *       perform validation in register (code is already written in comment down there)
-         */
+     * TODO: alter register (and others) to take schema, not collection
+     *       perform validation in register (code is already written in comment down there)
+     */
     // validate mapping, since it can't (currently) happen in generic register function
     // NOTE: this is a temporary fix. Do TODO above!
     const target = await this.db
@@ -776,6 +780,17 @@ export class MongoDriver implements DataStore {
   ///////////////////////////
   // INFORMATION RETRIEVAL //
   ///////////////////////////
+
+  /**
+   * Fetches Stats for Learning Objects
+   *
+   * @param {{ query: any }} params
+   * @returns {Promise<Partial<LearningObjectStats>>}
+   * @memberof MongoDriver
+   */
+  fetchStats(params: { query: any }): Promise<Partial<LearningObjectStats>> {
+    return this.statStore.fetchStats({ query: params.query });
+  }
 
   /**
    * Get LearningObject IDs owned by User
@@ -1106,13 +1121,13 @@ export class MongoDriver implements DataStore {
   }
 
   /* Search for objects on CuBE criteria.
-    *
-    * TODO: Efficiency very questionable.
-    *      Convert to streaming algorithm if possible.
-    *
-    * TODO: behavior is currently very strict (ex. name, author must exactly match)
-    *       Consider text-indexing these fields to exploit mongo $text querying.
-    */
+   *
+   * TODO: Efficiency very questionable.
+   *      Convert to streaming algorithm if possible.
+   *
+   * TODO: behavior is currently very strict (ex. name, author must exactly match)
+   *       Consider text-indexing these fields to exploit mongo $text querying.
+   */
   // tslint:disable-next-line:member-ordering
   async searchObjects(params: {
     name: string;
@@ -1440,8 +1455,8 @@ export class MongoDriver implements DataStore {
         skip !== undefined
           ? cursor.skip(skip).limit(filters.limit)
           : filters.limit
-            ? cursor.limit(filters.limit)
-            : cursor;
+          ? cursor.limit(filters.limit)
+          : cursor;
 
       // SortBy
       cursor = filters.orderBy

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -1,18 +1,31 @@
-import { DataStore, LibraryCommunicator, FileManager } from '../../interfaces/interfaces';
+import {
+  DataStore,
+  LibraryCommunicator,
+  FileManager,
+} from '../../interfaces/interfaces';
 import { Router } from 'express';
 import { LearningObjectInteractor } from '../../interactors/interactors';
 import { LearningObject } from '@cyber4all/clark-entity';
 import * as TokenManager from '../TokenManager';
 import { LearningObjectQuery } from '../../interfaces/DataStore';
 import { reportError } from '../SentryConnector';
+import * as LearningObjectStatsRouteHandler from '../../LearningObjectStats/LearningObjectStatsRouteHandler';
 // This refers to the package.json that is generated in the dist. See /gulpfile.js for reference.
 // tslint:disable-next-line:no-require-imports
 const version = require('../../../package.json').version;
 
 export class ExpressRouteDriver {
-  constructor(private dataStore: DataStore, private library: LibraryCommunicator, private fileManager: FileManager) {}
+  constructor(
+    private dataStore: DataStore,
+    private library: LibraryCommunicator,
+    private fileManager: FileManager,
+  ) {}
 
-  public static buildRouter(dataStore: DataStore, library: LibraryCommunicator, fileManager: FileManager): Router {
+  public static buildRouter(
+    dataStore: DataStore,
+    library: LibraryCommunicator,
+    fileManager: FileManager,
+  ): Router {
     const e = new ExpressRouteDriver(dataStore, library, fileManager);
     const router: Router = Router();
     e.setRoutes(router);
@@ -255,6 +268,14 @@ export class ExpressRouteDriver {
           }
         }
       },
+    );
+
+    router.use(
+      '/learning-objects/stats',
+      LearningObjectStatsRouteHandler.initialize({
+        dataStore: this.dataStore,
+        library: this.library,
+      }),
     );
   }
 }

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -6,8 +6,9 @@ import {
 } from './FileManager';
 import { LearningObjectLock } from '@cyber4all/clark-entity/dist/learning-object';
 import { LearningObjectFile } from '../interactors/LearningObjectInteractor';
+import { LearningObjectStatDatastore } from '../LearningObjectStats/LearningObjectStatsInteractor';
 
-export interface DataStore {
+export interface DataStore extends LearningObjectStatDatastore {
   connect(dburi: string): Promise<void>;
   disconnect(): void;
   insertLearningObject(object: LearningObject): Promise<string>;
@@ -39,24 +40,22 @@ export interface DataStore {
     page?: number,
     limit?: number,
   ): Promise<{ objects: LearningObject[]; total: number }>;
-  searchObjects(
-    params: {
-      name: string,
-      author: string,
-      collection: string,
-      status: string[],
-      length: string[],
-      level: string[],
-      standardOutcomeIDs: string[],
-      text: string,
-      accessUnpublished?: boolean,
-      orderBy?: string,
-      sortType?: number,
-      page?: number,
-      limit?: number,
-      released?: boolean,
-    },
-  ): Promise<{ objects: LearningObject[]; total: number }>;
+  searchObjects(params: {
+    name: string;
+    author: string;
+    collection: string;
+    status: string[];
+    length: string[];
+    level: string[];
+    standardOutcomeIDs: string[];
+    text: string;
+    accessUnpublished?: boolean;
+    orderBy?: string;
+    sortType?: number;
+    page?: number;
+    limit?: number;
+    released?: boolean;
+  }): Promise<{ objects: LearningObject[]; total: number }>;
   fetchCollections(loadObjects?: boolean): Promise<Collection[]>;
   fetchCollection(name: string): Promise<Collection>;
   fetchCollectionMeta(name: string): Promise<any>;


### PR DESCRIPTION
Added a route `/learning-objects/stats` to fetch the following properties about the  learning object collection:
- Downloads
- Saves
- Number of objects by length

This route accepts query parameters for `collection`, `name`, `authorID`, `length`, and `status`.