### PR TITLE
Fix Single FIle Downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.8.1",
+  "version": "1.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/S3Driver.ts
+++ b/src/FileManager/S3Driver.ts
@@ -246,7 +246,7 @@ export class S3Driver implements FileManager {
         .on('finish', _ => resolve(true))
         .on('error', (e: AWSError) => {
           resolve(false);
-          console.log(e);
+          reportError(e);
         });
     });
   }

--- a/src/FileManager/S3Driver.ts
+++ b/src/FileManager/S3Driver.ts
@@ -8,6 +8,8 @@ import {
   CompletedPartList,
 } from '../interfaces/FileManager';
 import { Readable } from 'stream';
+import { reportError } from '../drivers/SentryConnector';
+import { AWSError } from 'aws-sdk';
 
 AWS.config.credentials = AWS_SDK_CONFIG.credentials;
 
@@ -15,6 +17,7 @@ const AWS_S3_BUCKET = 'neutrino-file-uploads';
 const AWS_S3_ACL = 'public-read';
 
 export class S3Driver implements FileManager {
+
   private s3 = new AWS.S3({ region: AWS_SDK_CONFIG.region });
 
   /**
@@ -193,12 +196,18 @@ export class S3Driver implements FileManager {
     }
   }
 
-  streamFile(params: { path: string }): Readable {
+  streamFile(params: { path: string, objectName: string }): Readable {
     const fetchParams = {
       Bucket: AWS_S3_BUCKET,
       Key: params.path,
     };
-    return this.s3.getObject(fetchParams).createReadStream();
+    const stream = this.s3
+      .getObject(fetchParams)
+      .createReadStream()
+      .on('error', (err: AWSError) => {
+        reportError(err);
+      });
+    return stream;
   }
 
   /**
@@ -216,5 +225,29 @@ export class S3Driver implements FileManager {
     } catch (e) {
       return Promise.reject(e);
     }
+  }
+
+  /**
+   * Sends a HEAD request to fetch metadata for a given file.
+   * Resolves true if the request completes, and false if the request
+   * stream encounters an error at any point.
+   *
+   * @param path the file path in S3
+   */
+  async hasAccess(path: string): Promise<boolean> {
+    const fetchParams = {
+      Bucket: AWS_S3_BUCKET,
+      Key: path,
+    };
+    return new Promise<boolean>((resolve) => {
+      this.s3
+        .headObject(fetchParams)
+        .createReadStream()
+        .on('finish', _ => resolve(true))
+        .on('error', (e: AWSError) => {
+          resolve(false);
+          console.log(e);
+        });
+    });
   }
 }

--- a/src/assets/filenotfound.ts
+++ b/src/assets/filenotfound.ts
@@ -1,0 +1,27 @@
+/**
+ * Creates an HTML document declaring that the file was not found.
+ *
+ * @param redirectUrl the URL to send the user to
+ */
+export function fileNotFound(redirectUrl: string) {
+  return `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <meta charset="UTF-8">
+      <title>File Not Found</title>
+    </head>
+    <body>
+      <div><h1>File Not Found</h1></div>
+      <div>
+        <p>
+          The requested file does not exist.
+          <br/>
+          <br/>
+          You can find the latest materials for this learning object <a href="${redirectUrl}">here.</a>
+        </p>
+      </div>
+    </body>
+  </html>
+  `;
+}

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -3,7 +3,7 @@ import {
   LibraryCommunicator,
   FileManager,
 } from '../../interfaces/interfaces';
-import { Router } from 'express';
+import { Router, Response, Request } from 'express';
 import { LearningObjectInteractor } from '../../interactors/interactors';
 import { LearningObject } from '@cyber4all/clark-entity';
 import * as TokenManager from '../TokenManager';
@@ -11,6 +11,7 @@ import { LearningObjectQuery } from '../../interfaces/DataStore';
 import { reportError } from '../SentryConnector';
 import * as LearningObjectStatsRouteHandler from '../../LearningObjectStats/LearningObjectStatsRouteHandler';
 import { LEARNING_OBJECT_ROUTES } from '../../routes';
+import { fileNotFound } from '../../assets/filenotfound';
 
 // This refers to the package.json that is generated in the dist. See /gulpfile.js for reference.
 // tslint:disable-next-line:no-require-imports
@@ -264,21 +265,7 @@ export class ExpressRouteDriver {
                 'Invalid Access. You do not have download privileges for this file',
               );
           } else if (e.message === 'File not found') {
-            const redirectUrl = LEARNING_OBJECT_ROUTES.CLARK_DETAILS({
-              objectName: e.object.name,
-              username: req.params.username,
-            });
-            res.send(`
-            <div><h1>File Not Found</h1></div>
-            <div>
-              <p>
-                The requested file does not exist.
-                <br/>
-                <br/>
-                You can find the latest materials for this learning object <a href="${redirectUrl}">here.</a>
-              </p>
-            </div>
-            `);
+            fileNotFoundResponse(e.object, req, res);
           } else {
             console.error(e);
             reportError(e);
@@ -296,4 +283,12 @@ export class ExpressRouteDriver {
       }),
     );
   }
+}
+
+function fileNotFoundResponse(object: any, req: Request, res: Response) {
+  const redirectUrl = LEARNING_OBJECT_ROUTES.CLARK_DETAILS({
+    objectName: object.name,
+    username: req.params.username,
+  });
+  res.status(404).type('text/html').send(fileNotFound(redirectUrl));
 }

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -255,7 +255,8 @@ export class ExpressRouteDriver {
           if (!open) {
             res.attachment(filename);
           }
-          res.contentType(mimeType);
+          // Set mime type only if it is known
+          if (mimeType) res.contentType(mimeType);
           stream.pipe(res);
         } catch (e) {
           if (e.message === 'Invalid Access') {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -414,10 +414,10 @@ export class LearningObjectInteractor {
       );
     }
 
-        // Collect requested file metadata from datastore
+    // Collect requested file metadata from datastore
     fileMetaData = await params.dataStore.findSingleFile({
-          learningObjectId: params.learningObjectId,
-          fileId: params.fileId,
+      learningObjectId: params.learningObjectId,
+      fileId: params.fileId,
     });
 
     if (!fileMetaData) {
@@ -427,13 +427,18 @@ export class LearningObjectInteractor {
       });
     }
 
-      const path = `${params.author}/${params.learningObjectId}/${
-        fileMetaData.fullPath ? fileMetaData.fullPath : fileMetaData.name
+    const path = `${params.author}/${params.learningObjectId}/${
+      fileMetaData.fullPath ? fileMetaData.fullPath : fileMetaData.name
       }`;
-      const mimeType = fileMetaData.fileType;
-      const stream = params.fileManager.streamFile({ path });
+    const mimeType = fileMetaData.fileType;
+    // Check if the file manager has access to the resource before opening a stream
+    if (await params.fileManager.hasAccess(path)) {
+      const stream = params.fileManager.streamFile({ path, objectName: learningObject.name });
       return { mimeType, stream, filename: fileMetaData.name };
+    } else {
+      throw { message: 'File not found', object: { name: learningObject.name }};
     }
+  }
 
   /**
    * Inserts metadata for file as LearningObjectFile

--- a/src/interfaces/FileManager.ts
+++ b/src/interfaces/FileManager.ts
@@ -11,7 +11,8 @@ export interface FileManager {
     completedPartList?: CompletedPartList;
   }): Promise<MultipartUploadData>;
   cancelMultipart(params: { path: string; uploadId: string }): Promise<void>;
-  streamFile(params: { path: string }): Readable;
+  streamFile(params: { path: string, objectName: string }): Readable;
+  hasAccess(path: string): Promise<boolean>;
 }
 
 // Export aliased types for ease of update in the case that AWS S3 is no longer the driver used.


### PR DESCRIPTION
Errors in the single file download route were causing the learning object service to crash. The problem was that an error was being thrown in the stream, after it was opened to S3 and being piped to the client. This PR adds a function to send a HEAD request to S3 to verify that the file is accessible before opening the stream.

Additionally, some files did not have a `fileType` set which was resulting in the RouteHandler attempting to set a mimeType of `null`. This is not supported by the express API and was throwing an error.