### PR TITLE
Remove error report for canceled downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/S3Driver.ts
+++ b/src/FileManager/S3Driver.ts
@@ -205,7 +205,10 @@ export class S3Driver implements FileManager {
       .getObject(fetchParams)
       .createReadStream()
       .on('error', (err: AWSError) => {
-        reportError(err);
+        // TimeoutError will be thrown if the client cancels the download
+        if (err.code !== 'TimeoutError') {
+          reportError(err);
+        }
       });
     return stream;
   }


### PR DESCRIPTION
If the client cancels a download that is in progress, the file stream coming from S3 will throw an error after a timeout window. This PR adds a check to prevent this from being reported.

Resolves #148