### PR TITLE
:bug: Remove public access to unpublished objects

### DIFF
--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -226,7 +226,7 @@ export class ExpressRouteDriver {
             dataStore: this.dataStore,
             library: this.library,
             username: req.params.username,
-            accessUnpublished: true,
+            accessUnpublished: false,
             loadChildren: true,
           },
         );


### PR DESCRIPTION
**Issue**
The public route for fetching a user's public Learning Objects passed in an `accessUnpublished` value of `true` allowing other users to see a user's unpublished Learning Objects.

**Solution**
Change `accessUnpublished` to false to restrict access to unpublished Learning Objects.