### PR TITLE
:bug: Fix incorrect LearningObject date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {


### PR DESCRIPTION
This PR fixes issue #194. This issue was caused by the `generateLearningObject` method using LearningObject's setters to construct the object which unintentionally updated objects' date to the current timestamp.

**Solution**
Refactor logic to fetch all data and pass in via the LearningObject's constructor.