### PR TITLE
Add handler for jwt middleware errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -53,6 +53,7 @@ export class ExpressDriver {
     // Set up cookie parser
     this.app.use(cookieParser());
 
+    // Handles any errors that may occur when processing the token by passing execution to the next handler. This prevents this error from being passed to other error handlers.
     this.app.use(processToken, (error: any, req: any, res: any, next: any) =>
       next(),
     );

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -29,9 +29,7 @@ export class ExpressDriver {
     fileManager: FileManager,
     library: LibraryCommunicator,
   ) {
-    raven
-      .config(process.env.SENTRY_DSN)
-      .install();
+    raven.config(process.env.SENTRY_DSN).install();
 
     this.app.use(raven.requestHandler());
     this.app.use(raven.errorHandler());
@@ -55,10 +53,15 @@ export class ExpressDriver {
     // Set up cookie parser
     this.app.use(cookieParser());
 
-    this.app.use(processToken);
+    this.app.use(processToken, (error: any, req: any, res: any, next: any) =>
+      next(),
+    );
 
     // Set our public api routes
-    this.app.use('/', ExpressRouteDriver.buildRouter(dataStore, library, fileManager));
+    this.app.use(
+      '/',
+      ExpressRouteDriver.buildRouter(dataStore, library, fileManager),
+    );
 
     // Set Validation Middleware
     this.app.use(enforceAuthenticatedAccess);


### PR DESCRIPTION
**Issue**
When an invalid token was handed to the service, an error would be thrown causing the express router to fall through to the first error handling middleware. This middleware happened to be the error handler for authenticated access causing a 401 and `Invalid Access Token` to be sent to the client.

**Solution**
Add error handling middleware after the `processToken` middleware to catch errors and pass execution to the next handler.