### PR TITLE
Use build method to get Datastore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,4 @@
-import {
-  ExpressDriver,
-  MongoDriver,
-  S3Driver,
-} from './drivers/drivers';
+import { ExpressDriver, MongoDriver, S3Driver } from './drivers/drivers';
 import {
   DataStore,
   FileManager,
@@ -39,9 +35,8 @@ switch (process.env.NODE_ENV) {
   default:
     break;
 }
-
-const dataStore: DataStore = new MongoDriver(dburi);
 const fileManager: FileManager = new S3Driver();
 const library: LibraryCommunicator = new LibraryDriver();
-// ----------------------------------------------------------------------------------
-ExpressDriver.start(dataStore, fileManager, library);
+MongoDriver.build(dburi).then(dataStore => {
+  ExpressDriver.start(dataStore, fileManager, library);
+});


### PR DESCRIPTION
**Issue**
The root was not updated to get the fully constructed `MongoDriver` using the `build` method causing `db` to be undefined.

**Solution**
Use build method at app root.