### PR TITLE
Update aggregation to count released objects by status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectStats/LearningObjectStatStore.ts
+++ b/src/LearningObjectStats/LearningObjectStatStore.ts
@@ -4,6 +4,7 @@ import {
 } from './LearningObjectStatsInteractor';
 import { Db } from 'mongodb';
 import { COLLECTIONS } from '../drivers/MongoDriver';
+import { LearningObject } from '@cyber4all/clark-entity';
 
 const USAGE_STATS_COLLECTION = 'usage-stats';
 const BLOOMS_DISTRIBUTION_COLLECTION = 'blooms_outcome_distribution';
@@ -42,12 +43,7 @@ export class LearningObjectStatStore implements LearningObjectStatDatastore {
             released: {
               $sum: {
                 $cond: [
-                  {
-                    $and: [
-                      { $eq: ['$published', true] },
-                      { $eq: ['$lock', null] },
-                    ],
-                  },
+                  { $eq: ['$status', LearningObject.Status.RELEASED] },
                   1,
                   0,
                 ],

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -1114,14 +1114,14 @@ export class MongoDriver implements DataStore {
     released?: boolean,
   ) {
     let query: any = <any>{};
+
     if (!accessUnpublished) {
       query.published = true;
     }
+
     if (released) {
       // Check that the learning object does not have a download restriction
-      query['lock.restrictions'] = {
-        $nin: [LearningObject.Restriction.DOWNLOAD],
-      };
+      query.status = LearningObject.Status.RELEASED;
     }
     // Search By Text
     if (text || text === '') {


### PR DESCRIPTION
This PR modifies the aggregation query to fetch LearningObject stats to only count objects as released if their status is released.