### PR TITLE
Fix bad function call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/SingleFileDownload/SingleFileDownloadInteractor.ts
+++ b/src/SingleFileDownload/SingleFileDownloadInteractor.ts
@@ -22,9 +22,10 @@ export async function downloadSingleFile(params: {
 }): Promise<{ filename: string; mimeType: string; stream: Readable }> {
   let learningObject, fileMetaData;
 
-  learningObject = await params.dataStore.fetchLearningObject(
-    params.learningObjectId,
-  );
+  learningObject = await params.dataStore.fetchLearningObject({
+    id: params.learningObjectId,
+    full: true,
+  });
 
   if (!learningObject) {
     throw new Error(


### PR DESCRIPTION
Refactoring of the Single File Download business logic was missed when refactoring the the datastore method's function signature.

I have updated it to now use the new function signature. I've set it to request the full object, as I believe that without that the file information does not come through.

Resolves #223 