### PR TITLE
:ambulance: Fix broken search for reviewers/curators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -161,12 +161,13 @@ export class MongoDriver implements DataStore {
       text,
       outcomeIDs,
     });
-
     let cursor = this.db
       .collection<LearningObjectDocument>(COLLECTIONS.LEARNING_OBJECTS)
       .find({
-        ...searchQuery,
-        $or: orConditions,
+        $and : [
+          searchQuery,
+          { $or: orConditions },
+        ]
       });
 
     const total = await cursor.count();


### PR DESCRIPTION
Faulty logic in the mongo driver's query for reviewers/curators was replacing the search query with the access privileges, thus showing every object a reviewer/curator had access to see on each search.