### PR TITLE
Remove invalid characters in LO name for PDF filename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/PDFKitDriver.ts
+++ b/src/LearningObjects/PDFKitDriver.ts
@@ -151,7 +151,7 @@ function addEventListeners(
   return new Promise<LearningObject.Material.PDF>(resolve => {
     doc.on('end', async () => {
       const buffer: Buffer = Buffer.concat(buffers);
-      const fileName = `0ReadMeFirst - ${sanitizePath(
+      const fileName = `0ReadMeFirst - ${sanitizeLearningObjectName(
         learningObject.name,
       )}.pdf`;
       const path = `${learningObject.author.username}/${
@@ -499,11 +499,11 @@ export function titleCase(text: string): string {
 }
 
 /**
- * Replaces invalid characters with _ characters
+ * Replaces invalid file path characters in a Learning Object's name with _ characters
  *
  * @param {string} path
  * @returns {string}
  */
-function sanitizePath(path: string): string {
+function sanitizeLearningObjectName(path: string): string {
   return path.replace(/[\\/:"*?<>|]/gi, '_');
 }

--- a/src/LearningObjects/PDFKitDriver.ts
+++ b/src/LearningObjects/PDFKitDriver.ts
@@ -151,7 +151,9 @@ function addEventListeners(
   return new Promise<LearningObject.Material.PDF>(resolve => {
     doc.on('end', async () => {
       const buffer: Buffer = Buffer.concat(buffers);
-      const fileName = `0ReadMeFirst - ${learningObject.name}.pdf`;
+      const fileName = `0ReadMeFirst - ${sanitizePath(
+        learningObject.name,
+      )}.pdf`;
       const path = `${learningObject.author.username}/${
         learningObject.id
       }/${fileName}`;
@@ -494,4 +496,14 @@ export function titleCase(text: string): string {
     textArr[i] = word;
   }
   return textArr.join(' ');
+}
+
+/**
+ * Replaces invalid characters with _ characters
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+function sanitizePath(path: string): string {
+  return path.replace(/[\\/:"*?<>|]/gi, '_');
 }


### PR DESCRIPTION
**Issue**
Learning Objects with `:` characters in the name would cause the `:` character to be replaced with `/` characters in the PDF file name.

**Solution**
Replace characters that are potentially invalid with `_` characters when constructing the PDF file name.

Closes #146