### PR TITLE
implement endpoint tests in the service 

### DIFF
--- a/src/LearningOutcomes/LearningOutcomeInteractor.ts
+++ b/src/LearningOutcomes/LearningOutcomeInteractor.ts
@@ -10,7 +10,7 @@ import { sanitizeObject } from '../functions';
 export interface LearningOutcomeDatastore {
   insertLearningOutcome(params: {
     source: string;
-    outcome: LearningOutcomeInput & LearningOutcomeInsert;
+    outcome: Partial<LearningOutcome>;
   }): Promise<string>;
   getLearningOutcome(params: { id: string }): Promise<LearningOutcome>;
   getAllLearningOutcomes(params: {
@@ -39,19 +39,15 @@ export async function addLearningOutcome(params: {
   dataStore: LearningOutcomeDatastore;
   user: UserToken;
   source: string;
-  outcomeInput: LearningOutcomeInput;
+  outcomeInput: Partial<LearningOutcome>;
 }): Promise<string> {
   try {
-    const outcome: LearningOutcomeInput & LearningOutcomeInsert = {
-      ...sanitizeObject<LearningOutcomeInput>(
-        { object: params.outcomeInput },
-        false,
-      ),
-      date: Date.now().toString(),
-    };
-    return await params.dataStore.insertLearningOutcome({
-      outcome,
-      source: params.source,
+    //FIXME: add authorization
+    const { dataStore, user, source, outcomeInput } = params;
+    const outcome = new LearningOutcome(outcomeInput);
+    return await dataStore.insertLearningOutcome({
+      outcome: outcome.toPlainObject(),
+      source,
     });
   } catch (e) {
     return Promise.reject(`Problem adding learning outcome. ${e}`);

--- a/src/LearningOutcomes/LearningOutcomeMongoDatastore.ts
+++ b/src/LearningOutcomes/LearningOutcomeMongoDatastore.ts
@@ -24,7 +24,7 @@ export class LearningOutcomeMongoDatastore implements LearningOutcomeDatastore {
    */
   async insertLearningOutcome(params: {
     source: string;
-    outcome: LearningOutcomeInput & LearningOutcomeInsert;
+    outcome: Partial<LearningOutcome>;
   }): Promise<string> {
     const id = new ObjectID().toHexString();
     params.outcome['_id'] = id;

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
@@ -14,92 +14,92 @@ app.use(router);
 
 const request = supertest(app);
 beforeAll(async () => {
- const driver: MongoDriver = await MongoDriver.build(global['__MONGO_URI__']);
- let dataStore = driver.learningOutcomeStore;
- LearningOutcomeRouteHandler.initialize({ router, dataStore });
+  const driver: MongoDriver = await MongoDriver.build(global['__MONGO_URI__']);
+  let dataStore = driver.learningOutcomeStore;
+  LearningOutcomeRouteHandler.initialize({ router, dataStore });
 });
 describe('POST /learning-objects/:id/learning-outcomes', () => {
- it('should return a status of 200 and the id of the inserted outcome', done => {
-   request
-     .post('/learning-objects/someObjectId/learning-outcomes')
-     .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
-     .expect('Content-Type', /text/)
-     .expect(200)
-     .then(res => {
-       expect(res.text).toBeDefined();
-       done();
-     });
- });
+  it('should return a status of 200 and the id of the inserted outcome', done => {
+    request
+      .post('/learning-objects/someObjectId/learning-outcomes')
+      .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
+      .expect('Content-Type', /text/)
+      .expect(200)
+      .then(res => {
+        expect(res.text).toBeDefined();
+        done();
+      });
+  });
 
- it('should return a status of 500 and an error message', done => {
-   request
-     .post('/learning-objects/someObjectId/learning-outcomes')
-     .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
-     .expect('Content-Type', /text/)
-     .expect(500)
-     .then(res => {
-       expect(res.text).toMatch('Problem');
-       done();
-     });
- });
+  it('should return a status of 500 and an error message', done => {
+    request
+      .post('/learning-objects/someObjectId/learning-outcomes')
+      .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
+      .expect('Content-Type', /text/)
+      .expect(500)
+      .then(res => {
+        expect(res.text).toMatch('Problem');
+        done();
+      });
+  });
 });
 
 describe('GET /learning-objects/:id/learning-outcomes/:outcomeId', () => {
- it('should return a status of 200 and a Learning Outcome', done => {
-   request
-     .get(
-       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
-     )
-     .expect('Content-Type', /json/)
-     .expect(200)
-     .then(res => {
-       expect(() => {
-         const _ = new LearningOutcome(res.body);
-       }).not.toThrow();
-       done();
-     });
- });
+  it('should return a status of 200 and a Learning Outcome', done => {
+    request
+      .get(
+        '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+      )
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(res => {
+        expect(() => {
+          const _ = new LearningOutcome(res.body);
+        }).not.toThrow();
+        done();
+      });
+  });
 });
 
 describe('PATCH /learning-objects/:id/learning-outcomes/:outcomeId', () => {
- it('should return a status of 200 and a Learning Outcome', done => {
-   request
-     .patch(
-       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
-     )
-     .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
-     .expect('Content-Type', /json/)
-     .expect(200)
-     .then(res => {
-       expect(() => {
-         const _ = new LearningOutcome(res.body);
-       }).not.toThrow();
-       done();
-     });
- });
+  it('should return a status of 200 and a Learning Outcome', done => {
+    request
+      .patch(
+        '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+      )
+      .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .then(res => {
+        expect(() => {
+          const _ = new LearningOutcome(res.body);
+        }).not.toThrow();
+        done();
+      });
+  });
 
- it('should return a status of 500 and an error message', done => {
-   request
-     .patch(
-       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
-     )
-     .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
-     .expect('Content-Type', /text/)
-     .expect(500)
-     .then(res => {
-       expect(res.text).toMatch('Problem');
-       done();
-     });
- });
+  it('should return a status of 500 and an error message', done => {
+    request
+      .patch(
+        '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+      )
+      .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
+      .expect('Content-Type', /text/)
+      .expect(500)
+      .then(res => {
+        expect(res.text).toMatch('Problem');
+        done();
+      });
+  });
 });
 
 describe('DELETE /learning-objects/:id/learning-outcomes/:outcomeId', () => {
- it('should return a status of 200', done => {
-   request
-     .delete('/learning-objects/:id/learning-outcomes/:outcomeId')
-     .expect(200)
-     .then(res => {
-       done();
-     });
- });
+  it('should return a status of 200', done => {
+    request
+      .delete('/learning-objects/:id/learning-outcomes/:outcomeId')
+      .expect(200)
+      .then(res => {
+        done();
+      });
+  });
 });

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
@@ -1,137 +1,105 @@
 import * as express from 'express';
 import * as bodyParser from 'body-parser';
-import { LearningOutcomeDatastore } from './LearningOutcomeInteractor';
-import { LearningOutcomeInput, LearningOutcomeInsert, LearningOutcomeUpdate } from './types';
-import { LearningOutcome } from '@cyber4all/clark-entity';
+import { MongoDriver } from '../drivers/MongoDriver'
 import * as supertest from 'supertest';
 import * as LearningOutcomeRouteHandler from './LearningOutcomeRouteHandler';
-
-const validOutcome = new LearningOutcome({ verb: 'remember', bloom: 'remember and understand', text: 'to brush your teeth' });
-
-// FIXME instead of mocking out a datastore, we should implement the MongoDB Memory Server so that our tests hit the real datastore
-const dataStore: LearningOutcomeDatastore = {
-  async insertLearningOutcome(params: { source: string, outcome: LearningOutcomeInput & LearningOutcomeInsert }) {
-    try {
-      const _ = new LearningOutcome(Object.assign(params.outcome));
-      return Promise.resolve('someid');
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  },
-
-  async getLearningOutcome(params: { id: string }) {
-    return Promise.resolve(validOutcome);
-  },
-
-  async getAllLearningOutcomes(params: { source: string }) {
-    return Promise.resolve([validOutcome, validOutcome]);
-  },
-
-  async updateLearningOutcome(params: { id: string, updates: LearningOutcomeUpdate & LearningOutcomeInsert }) {
-    try {
-      const outcome = new LearningOutcome(Object.assign(params.updates));
-      return Promise.resolve(outcome);
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  },
-
-  async deleteLearningOutcome(params: { id: string }) {
-    return Promise.resolve();
-  },
-
-  async deleteAllLearningOutcomes(params: { source: string }) {
-    return Promise.resolve();
-  },
-};
+import { LearningOutcome } from '@cyber4all/clark-entity';
 
 const app = express();
 const router = express.Router();
-
-LearningOutcomeRouteHandler.initialize({ router, dataStore });
-
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(router);
 
 const request = supertest(app);
-
-
+beforeAll(async () => {
+ const driver: MongoDriver = await MongoDriver.build(global['__MONGO_URI__']);
+ let dataStore = driver.learningOutcomeStore;
+ LearningOutcomeRouteHandler.initialize({ router, dataStore });
+});
 describe('POST /learning-objects/:id/learning-outcomes', () => {
+ it('should return a status of 200 and the id of the inserted outcome', done => {
+   request
+     .post('/learning-objects/someObjectId/learning-outcomes')
+     .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
+     .expect('Content-Type', /text/)
+     .expect(200)
+     .then(res => {
+       expect(res.text).toBeDefined();
+       done();
+     });
+ });
 
-  it('should return a status of 200 and the id of the inserted outcome', (done) => {
-    request
-      .post('/learning-objects/someObjectId/learning-outcomes')
-      .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
-      .expect('Content-Type', /text/)
-      .expect(200)
-      .then(res => {
-        expect(res.text).toBe('someid');
-        done();
-      });
-  });
-
-  it('should return a status of 500 and an error message', (done) => {
-    request
-      .post('/learning-objects/someObjectId/learning-outcomes')
-      .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
-      .expect('Content-Type', /text/)
-      .expect(500)
-      .then(res => {
-        expect(res.text).toMatch('Problem');
-        done();
-      });
-  });
+ it('should return a status of 500 and an error message', done => {
+   request
+     .post('/learning-objects/someObjectId/learning-outcomes')
+     .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
+     .expect('Content-Type', /text/)
+     .expect(500)
+     .then(res => {
+       expect(res.text).toMatch('Problem');
+       done();
+     });
+ });
 });
 
 describe('GET /learning-objects/:id/learning-outcomes/:outcomeId', () => {
-
-  it('should return a status of 200 and a Learning Outcome', (done) => {
-    request.get('/learning-objects/someObjectId/learning-outcomes/someLearningOutcomeId')
-    .expect('Content-Type', /json/)
-    .expect(200)
-    .then(res => {
-      expect(() => {
-        const _ = new LearningOutcome(res.body);
-      }).not.toThrow();
-      done();
-    });
-  });
+ it('should return a status of 200 and a Learning Outcome', done => {
+   request
+     .get(
+       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+     )
+     .expect('Content-Type', /json/)
+     .expect(200)
+     .then(res => {
+       expect(() => {
+         const _ = new LearningOutcome(res.body);
+       }).not.toThrow();
+       done();
+     });
+ });
 });
 
 describe('PATCH /learning-objects/:id/learning-outcomes/:outcomeId', () => {
+ it('should return a status of 200 and a Learning Outcome', done => {
+   request
+     .patch(
+       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+     )
+     .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
+     .expect('Content-Type', /json/)
+     .expect(200)
+     .then(res => {
+       expect(() => {
+         const _ = new LearningOutcome(res.body);
+       }).not.toThrow();
+       done();
+     });
+ });
 
-  it('should return a status of 200 and a Learning Outcome', (done) => {
-    request.patch('/learning-objects/someObjectId/learning-outcomes/someLearningOutcomeId')
-      .send({ outcome: { bloom: 'remember and understand', verb: 'remember' } })
-      .expect('Content-Type', /json/)
-      .expect(200)
-      .then(res => {
-        expect(() => {
-          const _ = new LearningOutcome(res.body);
-        }).not.toThrow();
-        done();
-      });
-  });
-
-  it('should return a status of 500 and an error message', (done) => {
-    request.patch('/learning-objects/someObjectId/learning-outcomes/someLearningOutcomeId')
-      .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
-      .expect('Content-Type', /text/)
-      .expect(500)
-      .then(res => {
-        expect(res.text).toMatch('Problem');
-        done();
-      });
-  });
+ it('should return a status of 500 and an error message', done => {
+   request
+     .patch(
+       '/learning-objects/someObjectId/learning-outcomes/5af72b914803270dfc9aeae4',
+     )
+     .send({ outcome: { bloom: 'bad bloom', verb: 'badverb' } })
+     .expect('Content-Type', /text/)
+     .expect(500)
+     .then(res => {
+       expect(res.text).toMatch('Problem');
+       done();
+     });
+ });
 });
 
 describe('DELETE /learning-objects/:id/learning-outcomes/:outcomeId', () => {
-
-  it('should return a status of 200', (done) => {
-    request.delete('/learning-objects/:id/learning-outcomes/:outcomeId').expect(200).then(res => {
-      done();
-    });
-  });
+ it('should return a status of 200', done => {
+   request
+     .delete('/learning-objects/:id/learning-outcomes/:outcomeId')
+     .expect(200)
+     .then(res => {
+       done();
+     });
+ });
 });

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -334,7 +334,7 @@ export class MongoDriver implements DataStore {
   // LearningOutcome Ops
   insertLearningOutcome(params: {
     source: string;
-    outcome: LearningOutcomeInput & LearningOutcomeInsert;
+    outcome: Partial<LearningOutcome>; 
   }): Promise<string> {
     return this.learningOutcomeStore.insertLearningOutcome(params);
   }

--- a/test_environment/globalConfig.json
+++ b/test_environment/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:55321/4775168c-2d44-4d48-b6b7-bc2ff8589740"}
+{"mongoUri":"mongodb://127.0.0.1:34217/9aeb2c33-5ae1-4ee0-bf6b-9576f623159d"}


### PR DESCRIPTION
In the Learning-object-service, this PR utilizes the in-memory-mongodb server to run tests on the learning-outcome-routehandler specifically and properly validates inserted learning outcomes.