### PR TITLE
:bug: Fix call to copy object to collection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -133,7 +133,7 @@ export class MongoDriver implements DataStore {
     const doc = this.documentLearningObject(object);
     await this.db
       .collection(COLLECTIONS.RELEASED_LEARNING_OBJECTS)
-      .updateOne({ _id: object.id }, doc, { upsert: true });
+      .replaceOne({ _id: object.id }, doc, { upsert: true });
   }
   /**
    * Performs search on objects and released-objects collection based on query and or conditions


### PR DESCRIPTION
This PR fixes the issue where `addToReleased` function was throwing errors because the incorrect Mongo API call was being used.
Updated `updateOne` to `replaceOne`