### PR TITLE
Fix cyclic dependency caused by not awaiting promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -130,7 +130,7 @@ export class MongoDriver implements DataStore {
    * @memberof MongoDriver
    */
   async addToReleased(object: LearningObject): Promise<void> {
-    const doc = this.documentLearningObject(object);
+    const doc = await this.documentLearningObject(object);
     await this.db
       .collection(COLLECTIONS.RELEASED_LEARNING_OBJECTS)
       .replaceOne({ _id: object.id }, doc, { upsert: true });


### PR DESCRIPTION
This PR fixes the issue where objects were not properly copied to the released collection.This was caused by a missing `await` statement.

Closes #249 