### PR TITLE
Fix Learning Objects not being found if the released copy's name was different from working copy's name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.5",
+  "version": "2.12.6",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -1107,7 +1107,7 @@ export class MongoDriver implements DataStore {
     collection?: COLLECTIONS.RELEASED_LEARNING_OBJECTS;
   }): Promise<string> {
     const { authorId, name, collection } = params;
-      const doc = await this.db
+    const doc = await this.db
       .collection(collection || COLLECTIONS.LEARNING_OBJECTS)
       .findOne<LearningObjectDocument>(
         {
@@ -1115,12 +1115,31 @@ export class MongoDriver implements DataStore {
           name,
         },
         { projection: { _id: 1 } },
-        );
+      );
     if (doc) {
       return doc._id;
     }
     return null;
-    }
+  }
+
+  /**
+   * Looks up a released learning object by its author and name.
+   *
+   * @param {{
+   *     authorId: string; [Id of the author]
+   *     name: string; [name of the Learning Object]
+   *   }} params
+   * @returns {Promise<string>}
+   * @memberof MongoDriver
+   */
+  async findReleasedLearningObject(params: {
+    authorId: string;
+    name: string;
+  }): Promise<string> {
+    return this.findLearningObject({
+      ...params,
+      collection: COLLECTIONS.RELEASED_LEARNING_OBJECTS,
+    });
   }
 
   /**

--- a/src/drivers/express/ExpressAuthRouteDriver.ts
+++ b/src/drivers/express/ExpressAuthRouteDriver.ts
@@ -117,31 +117,6 @@ export class ExpressAuthRouteDriver {
         }
       },
     );
-    router.get(
-      '/learning-objects/:username/:learningObjectName/id',
-      async (req, res) => {
-        try {
-          const user = req.user;
-          const username = req.params.username;
-          const learningObjectName = req.params.learningObjectName;
-          if (this.hasAccess(user, 'username', username) || user.SERVICE_KEY) {
-            const id = await LearningObjectInteractor.findLearningObject(
-              this.dataStore,
-              username,
-              learningObjectName,
-            );
-            res.status(200).send(id);
-          } else {
-            res
-              .status(403)
-              .send('Invalid Access. Cannot fetch Learning Object ID.');
-          }
-        } catch (e) {
-          console.error(e);
-          res.status(500).send(e);
-        }
-      },
-    );
 
     // FILE MANAGEMENT
     router

--- a/src/interactors/LearningObject.interactor.spec.ts
+++ b/src/interactors/LearningObject.interactor.spec.ts
@@ -97,21 +97,3 @@ describe('fetchObjectsByIDs', () => {
       });
   });
 });
-
-describe('findLearningObject', () => {
-  it('should find a learning object ID', done => {
-    return LearningObjectInteractor.findLearningObject(
-      dataStore,
-      MOCK_OBJECTS.USERNAME,
-      MOCK_OBJECTS.LEARNING_OBJECT_NAME,
-    )
-      .then(val => {
-        expect(val).to.be.a('string');
-        done();
-      })
-      .catch(error => {
-        expect.fail();
-        done();
-      });
-  });
-});

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -331,7 +331,7 @@ export class LearningObjectInteractor {
    * @returns
    * @memberof LearningObjectInteractor
    */
-  private static async loadWorkingObject(params: {
+  private static async loadLearningObjectById(params: {
     dataStore: DataStore;
     learningObjectID: string;
     userToken: UserToken;

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -288,6 +288,89 @@ export class LearningObjectInteractor {
     } catch (e) {
       return Promise.reject(e);
     }
+
+  /**
+   * Loads working copy of a Learning Object by author's username and Learning Object's name
+   *
+   * @private
+   * @static
+   * @param {{
+   *     dataStore: DataStore;
+   *     authorUsername: string;
+   *     learningObjectName: string;
+   *     userToken: UserToken;
+   *   }} params
+   * @returns
+   * @memberof LearningObjectInteractor
+   */
+  private static async loadLearningObjectByAuthorAndName(params: {
+    dataStore: DataStore;
+    authorUsername: string;
+    learningObjectName: string;
+    userToken: UserToken;
+  }) {
+    const { dataStore, authorUsername, learningObjectName, userToken } = params;
+    const authorId = await this.findAuthorIdByUsername({
+      dataStore,
+      username: authorUsername,
+    });
+    const learningObjectID = await this.findLearningObjectIdByAuthorAndName({
+      dataStore,
+      authorId,
+      authorUsername,
+      name: learningObjectName,
+    });
+    return this.loadLearningObjectById({
+      dataStore,
+      learningObjectID,
+      userToken,
+      authorUsername,
+    });
+  }
+
+  /**
+   * Loads released Learning Object by author's id and Learning Object's name
+   *
+   * @private
+   * @static
+   * @param {{
+   *     dataStore: DataStore;
+   *     authorId: string;
+   *     authorUsername: string;
+   *     learningObjectName: string;
+   *   }} params
+   * @returns
+   * @memberof LearningObjectInteractor
+   */
+  private static async loadReleasedLearningObjectByAuthorAndName(params: {
+    dataStore: DataStore;
+    authorUsername: string;
+    learningObjectName: string;
+  }) {
+    const { dataStore, authorUsername, learningObjectName } = params;
+    const authorId = await this.findAuthorIdByUsername({
+      dataStore,
+      username: authorUsername,
+    });
+    const learningObjectID = await this.findReleasedLearningObjectIdByAuthorAndName(
+      {
+        dataStore,
+        authorId,
+        authorUsername,
+        name: learningObjectName,
+      },
+    );
+    const learningObject = await dataStore.fetchReleasedLearningObject({
+      id: learningObjectID,
+      full: true,
+    });
+    if (!learningObject) {
+      throw new ResourceError(
+        `A released Learning Object ${learningObjectName} by ${authorUsername} does not exist.`,
+        ResourceErrorReason.NOT_FOUND,
+      );
+    }
+    return learningObject;
   }
 
   /**

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -291,6 +291,33 @@ export class LearningObjectInteractor {
   }
 
   /**
+   * Finds author's id by username.
+   * If id is not found a ResourceError is thrown
+   *
+   * @private
+   * @param {{
+   *     dataStore: DataStore;
+   *     username: string;
+   *   }} params
+   * @returns {Promise<string>}
+   * @memberof LearningObjectInteractor
+   */
+  private static async findAuthorIdByUsername(params: {
+    dataStore: DataStore;
+    username: string;
+  }): Promise<string> {
+    const { dataStore, username } = params;
+    const authorId = await dataStore.findUser(username);
+    if (!authorId) {
+      throw new ResourceError(
+        `No user with username ${username} exists`,
+        ResourceErrorReason.NOT_FOUND,
+      );
+    }
+
+    return authorId;
+  }
+  /**
    * Fetches the working copy of an object if authorized
    *
    * @private

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -854,6 +854,7 @@ export class LearningObjectInteractor {
         const path = `${user.username}/${obj.id}/`;
         fileManager.deleteAll({ path }).catch(e => {
           console.error(`Problem deleting files at ${path}. ${e}`);
+          reportError(e);
         });
         // Update parents' dates
         updateParentsDate({

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -285,8 +285,8 @@ export class LearningObjectInteractor {
       return learningObject;
     } catch (e) {
       if (e instanceof ResourceError || e instanceof ServiceError) {
-      return Promise.reject(e);
-    }
+        return Promise.reject(e);
+      }
       reportError(e);
       throw new ServiceError(ServiceErrorReason.INTERNAL);
     }
@@ -823,11 +823,11 @@ export class LearningObjectInteractor {
         );
       }
 
-        // Get LearningObject ids
-        const objectRefs: {
-          id: string;
-          parentIds: string[];
-        }[] = await Promise.all(
+      // Get LearningObject ids
+      const objectRefs: {
+        id: string;
+        parentIds: string[];
+      }[] = await Promise.all(
         learningObjectNames.map(async (name: string) => {
           const authorId = await this.findAuthorIdByUsername({
             dataStore,
@@ -835,34 +835,34 @@ export class LearningObjectInteractor {
           });
           const id = await dataStore.findLearningObject({
             authorId,
-              name,
+            name,
           });
           const parentIds = await dataStore.findParentObjectIds({
-              childId: id,
-            });
-            return { id, parentIds };
-          }),
-        );
-        const objectIds = objectRefs.map(obj => obj.id);
-        // Remove objects from library
+            childId: id,
+          });
+          return { id, parentIds };
+        }),
+      );
+      const objectIds = objectRefs.map(obj => obj.id);
+      // Remove objects from library
       await library.cleanObjectsFromLibraries(objectIds);
-        // Delete objects from datastore
+      // Delete objects from datastore
       await dataStore.deleteMultipleLearningObjects(objectIds);
-        // For each object id
-        objectRefs.forEach(async obj => {
-          // Attempt to delete files
+      // For each object id
+      objectRefs.forEach(async obj => {
+        // Attempt to delete files
         const path = `${user.username}/${obj.id}/`;
         fileManager.deleteAll({ path }).catch(e => {
-            console.error(`Problem deleting files at ${path}. ${e}`);
-          });
-          // Update parents' dates
-          updateParentsDate({
-          dataStore,
-            parentIds: obj.parentIds,
-            childId: obj.id,
-            date: Date.now().toString(),
-          });
+          console.error(`Problem deleting files at ${path}. ${e}`);
         });
+        // Update parents' dates
+        updateParentsDate({
+          dataStore,
+          parentIds: obj.parentIds,
+          childId: obj.id,
+          date: Date.now().toString(),
+        });
+      });
     } catch (e) {
       if (e instanceof ResourceError || e instanceof ServiceError) {
         return Promise.reject(e);
@@ -1196,7 +1196,10 @@ export class LearningObjectInteractor {
   }): Promise<void> {
     try {
       const { dataStore, children, username, parentName } = params;
-      const authorId = await this.findAuthorIdByUsername({ dataStore, username });
+      const authorId = await this.findAuthorIdByUsername({
+        dataStore,
+        username,
+      });
       const parentID = await dataStore.findLearningObject({
         authorId,
         name: parentName,
@@ -1237,7 +1240,10 @@ export class LearningObjectInteractor {
   }) {
     try {
       const { dataStore, childId, username, parentName } = params;
-      const authorId = await this.findAuthorIdByUsername({ dataStore, username });
+      const authorId = await this.findAuthorIdByUsername({
+        dataStore,
+        username,
+      });
       const parentID = await dataStore.findLearningObject({
         authorId,
         name: parentName,

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -317,6 +317,75 @@ export class LearningObjectInteractor {
 
     return authorId;
   }
+
+  /**
+   * Finds Learning Object's id by name and authorID.
+   * If id is not found a ResourceError is thrown
+   *
+   * @private
+   * @param {{
+   *     dataStore: DataStore;
+   *     name: string; [Learning Object's name]
+   *     authorId: string [Learning Object's author's id]
+   *     authorUsername: string [Learning Object's author's username]
+   *   }} params
+   * @returns {Promise<string>}
+   * @memberof LearningObjectInteractor
+   */
+  private static async findLearningObjectIdByAuthorAndName(params: {
+    dataStore: DataStore;
+    name: string;
+    authorId: string;
+    authorUsername: string;
+  }): Promise<string> {
+    const { dataStore, name, authorId, authorUsername } = params;
+    const learningObjectId = await dataStore.findLearningObject({
+      authorId,
+      name,
+    });
+    if (!learningObjectId) {
+      throw new ResourceError(
+        `No Learning Object with name ${name} by ${authorUsername} exists`,
+        ResourceErrorReason.NOT_FOUND,
+      );
+    }
+    return learningObjectId;
+  }
+
+  /**
+   * Finds released Learning Object's id by name and authorID.
+   * If id is not found a ResourceError is thrown
+   *
+   * @private
+   * @param {{
+   *     dataStore: DataStore;
+   *     name: string; [Learning Object's name]
+   *     authorId: string [Learning Object's author's id]
+   *     authorUsername: string [Learning Object's author's username]
+   *   }} params
+   * @returns {Promise<string>}
+   * @memberof LearningObjectInteractor
+   */
+  private static async findReleasedLearningObjectIdByAuthorAndName(params: {
+    dataStore: DataStore;
+    name: string;
+    authorId: string;
+    authorUsername: string;
+  }): Promise<string> {
+    const { dataStore, name, authorId, authorUsername } = params;
+    const learningObjectId = await dataStore.findReleasedLearningObject({
+      authorId,
+      name,
+    });
+    if (!learningObjectId) {
+      throw new ResourceError(
+        `No released Learning Object with name ${name} by ${authorUsername} exists`,
+        ResourceErrorReason.NOT_FOUND,
+      );
+    }
+    return learningObjectId;
+  }
+
   /**
    * Fetches the working copy of an object if authorized
    *

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -346,10 +346,17 @@ export class LearningObjectInteractor {
       userToken,
       objectInfo: { author: authorUsername, status, collection },
     });
-    return dataStore.fetchLearningObject({
+    const learningObject = await dataStore.fetchLearningObject({
       id: learningObjectID,
       full: true,
     });
+    if (!learningObject) {
+      throw new ResourceError(
+        `No Learning Object with name ${name} by ${authorUsername} exists`,
+        ResourceErrorReason.NOT_FOUND,
+      );
+    }
+    return learningObject;
   }
 
   /**

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -602,18 +602,6 @@ export class LearningObjectInteractor {
    *
    * @returns {string} LearningOutcomeID
    */
-  public static async findLearningObject(
-    dataStore: DataStore,
-    username: string,
-    learningObjectName: string,
-  ): Promise<string> {
-    try {
-      return await dataStore.findLearningObject(username, learningObjectName);
-    } catch (e) {
-      return Promise.reject(`Problem finding LearningObject. Error: ${e}`);
-    }
-  }
-
   public static async deleteMultipleLearningObjects(params: {
     dataStore: DataStore;
     fileManager: FileManager;

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -39,7 +39,10 @@ export interface DataStore
 
   // Learning Objects
   getUserObjects(username: string): Promise<string[]>;
-  findLearningObject(username: string, name: string): Promise<string>;
+  findLearningObject(params: {
+    authorId: string;
+    name: string;
+  }): Promise<string>;
   fetchLearningObject(params: {
     id: string;
     full?: boolean;

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -43,6 +43,10 @@ export interface DataStore
     authorId: string;
     name: string;
   }): Promise<string>;
+  findReleasedLearningObject(params: {
+    authorId: string;
+    name: string;
+  }): Promise<string>;
   fetchLearningObject(params: {
     id: string;
     full?: boolean;

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -28,6 +28,12 @@ import {
 } from '../../entity';
 
 export class MockDataStore implements DataStore {
+  findLearningObject(params: {
+    authorId: string;
+    name: string;
+  }): Promise<string> {
+    return Promise.resolve(MOCK_OBJECTS.LEARNING_OBJECT_ID);
+  }
   connect(file: string): Promise<void> {
     return Promise.resolve();
   }

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -34,6 +34,12 @@ export class MockDataStore implements DataStore {
   }): Promise<string> {
     return Promise.resolve(MOCK_OBJECTS.LEARNING_OBJECT_ID);
   }
+  findReleasedLearningObject(params: {
+    authorId: string;
+    name: string;
+  }): Promise<string> {
+    return Promise.resolve(MOCK_OBJECTS.LEARNING_OBJECT_ID);
+  }
   connect(file: string): Promise<void> {
     return Promise.resolve();
   }
@@ -189,10 +195,6 @@ export class MockDataStore implements DataStore {
 
   getUserObjects(username: string): Promise<string[]> {
     return Promise.resolve([MOCK_OBJECTS.LEARNING_OBJECT_ID]);
-  }
-
-  findLearningObject(username: string, name: string): Promise<string> {
-    return Promise.resolve(MOCK_OBJECTS.LEARNING_OBJECT_ID);
   }
 
   fetchLearningObject(params: { id: string; full?: boolean }): Promise<any> {


### PR DESCRIPTION
This PR fixes the issue where Learning Objects could not be found if released copy's name was different from working copy's name.

Closes #250