### PR TITLE
:bug: Fix collection pointer in searchReleasedObjects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.4",
+  "version": "2.12.5",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -1369,7 +1369,6 @@ export class MongoDriver implements DataStore {
     params: ReleasedLearningObjectQuery,
   ): Promise<{ objects: LearningObject[]; total: number }> {
     try {
-      const status = [LearningObject.Status.RELEASED];
       const {
         author,
         text,
@@ -1394,7 +1393,6 @@ export class MongoDriver implements DataStore {
       let query: any = this.buildSearchQuery({
         text,
         authors,
-        status,
         length,
         level,
         outcomeIDs,
@@ -1403,7 +1401,7 @@ export class MongoDriver implements DataStore {
       });
 
       let objectCursor = await this.db
-        .collection(COLLECTIONS.LEARNING_OBJECTS)
+        .collection(COLLECTIONS.RELEASED_LEARNING_OBJECTS)
         .find<LearningObjectDocument>(query)
         .project({ score: { $meta: 'textScore' } })
         .sort({ score: { $meta: 'textScore' } });


### PR DESCRIPTION
This PR fixes the `objects` collection being queried in the `searchReleasedObjects` function instead of the `released-objects` collection.

Thinking this was merged out? :man_shrugging: 