### PR TITLE
Re-add route to fetch Learning Object's Id & Add authorization logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.7",
+  "version": "2.12.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.6",
+  "version": "2.12.7",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.7",
+  "version": "2.12.6",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressAuthRouteDriver.ts
+++ b/src/drivers/express/ExpressAuthRouteDriver.ts
@@ -117,6 +117,31 @@ export class ExpressAuthRouteDriver {
         }
       },
     );
+    router.get(
+      '/learning-objects/:username/:learningObjectName/id',
+      async (req, res) => {
+        try {
+          const user = req.user;
+          const username = req.params.username;
+          const learningObjectName = req.params.learningObjectName;
+          if (this.hasAccess(user, 'username', username) || user.SERVICE_KEY) {
+            const id = await LearningObjectInteractor.findLearningObject(
+              this.dataStore,
+              username,
+              learningObjectName,
+            );
+            res.status(200).send(id);
+          } else {
+            res
+              .status(403)
+              .send('Invalid Access. Cannot fetch Learning Object ID.');
+          }
+        } catch (e) {
+          console.error(e);
+          res.status(500).send(e);
+        }
+      },
+    );
 
     // FILE MANAGEMENT
     router

--- a/src/drivers/express/ExpressAuthRouteDriver.ts
+++ b/src/drivers/express/ExpressAuthRouteDriver.ts
@@ -18,7 +18,7 @@ import * as LearningOutcomeRouteHandler from '../../LearningOutcomes/LearningOut
 import * as SubmissionRouteDriver from '../../LearningObjectSubmission/SubmissionRouteDriver';
 import * as ChangelogRouteHandler from '../../Changelogs/ChangelogRouteDriver';
 import { reportError } from '../SentryConnector';
-import { ResourceErrorReason } from '../../errors';
+import { ResourceErrorReason, mapErrorToResponseData } from '../../errors';
 
 export class ExpressAuthRouteDriver {
   private upload = multer({ storage: multer.memoryStorage() });
@@ -121,24 +121,19 @@ export class ExpressAuthRouteDriver {
       '/learning-objects/:username/:learningObjectName/id',
       async (req, res) => {
         try {
-          const user = req.user;
+          const userToken = req.user;
           const username = req.params.username;
           const learningObjectName = req.params.learningObjectName;
-          if (this.hasAccess(user, 'username', username) || user.SERVICE_KEY) {
-            const id = await LearningObjectInteractor.findLearningObject(
-              this.dataStore,
-              username,
-              learningObjectName,
-            );
-            res.status(200).send(id);
-          } else {
-            res
-              .status(403)
-              .send('Invalid Access. Cannot fetch Learning Object ID.');
-          }
+          const id = await LearningObjectInteractor.getLearningObjectId({
+            dataStore: this.dataStore,
+            username,
+            learningObjectName,
+            userToken,
+          });
+          res.status(200).send(id);
         } catch (e) {
-          console.error(e);
-          res.status(500).send(e);
+          const { code, message } = mapErrorToResponseData(e);
+          res.status(code).json({ message });
         }
       },
     );

--- a/src/interactors/AuthorizationManager.ts
+++ b/src/interactors/AuthorizationManager.ts
@@ -1,4 +1,5 @@
-import { UserToken } from '../types';
+import 'dotenv/config';
+import { UserToken, ServiceToken } from '../types';
 import { DataStore } from '../interfaces/DataStore';
 
 enum UserRole {
@@ -186,4 +187,29 @@ export function getAccessGroupCollections(userToken: UserToken) {
     collections.push(access[1]);
   }
   return collections.filter(collection => !!collection);
+}
+
+/**
+ * Checks if requester is a service
+ *
+ * @export
+ * @param {ServiceToken} serviceToken
+ * @returns {boolean}
+ */
+export function hasServiceLevelAccess(serviceToken: ServiceToken): boolean {
+  if (serviceToken) {
+    return isValidServiceKey(serviceToken.SERVICE_KEY);
+  }
+  return false;
+}
+
+/**
+ * Checks if service key provided is valid
+ *
+ * @export
+ * @param {string} key
+ * @returns {boolean}
+ */
+function isValidServiceKey(key: string): boolean {
+  return key === process.env.SERVICE_KEY;
 }

--- a/src/interactors/AuthorizationManager.ts
+++ b/src/interactors/AuthorizationManager.ts
@@ -65,7 +65,7 @@ function hasPrivilegedWriteAccess(
   dataStore: DataStore,
   objectId: string,
 ) {
-  if (user.accessGroups) {
+  if (user && user.accessGroups) {
     if (isAdminOrEditor(user.accessGroups)) {
       return true;
     } else {
@@ -148,8 +148,9 @@ async function userIsOwner(params: {
  */
 export function isAdminOrEditor(accessGroups: string[]): boolean {
   return (
-    accessGroups.includes(UserRole.ADMIN) ||
-    accessGroups.includes(UserRole.EDITOR)
+    accessGroups &&
+    (accessGroups.includes(UserRole.ADMIN) ||
+      accessGroups.includes(UserRole.EDITOR))
   );
 }
 
@@ -160,14 +161,16 @@ export function isAdminOrEditor(accessGroups: string[]): boolean {
  * @returns {boolean}
  */
 export function isPrivilegedUser(accessGroups: string[]): boolean {
-  if (isAdminOrEditor(accessGroups)) {
-    return true;
-  }
-  for (const group of accessGroups) {
-    const access = group.split('@');
-    const role = access[0] ? access[0].toLowerCase() : null;
-    if (role === UserRole.CURATOR || role === UserRole.REVIEWER) {
+  if (accessGroups) {
+    if (isAdminOrEditor(accessGroups)) {
       return true;
+    }
+    for (const group of accessGroups) {
+      const access = group.split('@');
+      const role = access[0] ? access[0].toLowerCase() : null;
+      if (role === UserRole.CURATOR || role === UserRole.REVIEWER) {
+        return true;
+      }
     }
   }
   return false;
@@ -182,9 +185,11 @@ export function isPrivilegedUser(accessGroups: string[]): boolean {
  */
 export function getAccessGroupCollections(userToken: UserToken) {
   const collections = [];
-  for (const group of userToken.accessGroups) {
-    const access = group.split('@');
-    collections.push(access[1]);
+  if (userToken && userToken.accessGroups) {
+    for (const group of userToken.accessGroups) {
+      const access = group.split('@');
+      collections.push(access[1]);
+    }
   }
   return collections.filter(collection => !!collection);
 }

--- a/src/interactors/LearningObject.interactor.spec.ts
+++ b/src/interactors/LearningObject.interactor.spec.ts
@@ -97,3 +97,21 @@ describe('fetchObjectsByIDs', () => {
       });
   });
 });
+
+describe('findLearningObject', () => {
+  it('should find a learning object ID', done => {
+    return LearningObjectInteractor.findLearningObject(
+      dataStore,
+      MOCK_OBJECTS.USERNAME,
+      MOCK_OBJECTS.LEARNING_OBJECT_NAME,
+    )
+      .then(val => {
+        expect(val).to.be.a('string');
+        done();
+      })
+      .catch(error => {
+        expect.fail();
+        done();
+      });
+  });
+});

--- a/src/interactors/LearningObject.interactor.spec.ts
+++ b/src/interactors/LearningObject.interactor.spec.ts
@@ -29,7 +29,6 @@ describe('loadUsersObjectSummaries', () => {
 });
 
 describe('loadProfile', () => {
-
   it('should return an array of learning object summaries', done => {
     return LearningObjectInteractor.loadProfile({
       dataStore,
@@ -61,7 +60,6 @@ describe('loadProfile', () => {
         done();
       });
   });
-
 });
 
 describe('fetchObjectsByIDs', () => {
@@ -98,13 +96,14 @@ describe('fetchObjectsByIDs', () => {
   });
 });
 
-describe('findLearningObject', () => {
+describe('getLearningObjectId', () => {
   it('should find a learning object ID', done => {
-    return LearningObjectInteractor.findLearningObject(
+    return LearningObjectInteractor.getLearningObjectId({
       dataStore,
-      MOCK_OBJECTS.USERNAME,
-      MOCK_OBJECTS.LEARNING_OBJECT_NAME,
-    )
+      username: MOCK_OBJECTS.USERNAME,
+      learningObjectName: MOCK_OBJECTS.LEARNING_OBJECT_NAME,
+      userToken: MOCK_OBJECTS.USERTOKEN,
+    })
       .then(val => {
         expect(val).to.be.a('string');
         done();

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -811,6 +811,18 @@ export class LearningObjectInteractor {
    * @returns {Promise<void>}
    * @memberof LearningObjectInteractor
    */
+  public static async findLearningObject(
+    dataStore: DataStore,
+    username: string,
+    learningObjectName: string,
+  ): Promise<string> {
+    try {
+      return await dataStore.findLearningObject(username, learningObjectName);
+    } catch (e) {
+      return Promise.reject(`Problem finding LearningObject. Error: ${e}`);
+    }
+  }
+
   public static async deleteMultipleLearningObjects(params: {
     dataStore: DataStore;
     fileManager: FileManager;

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1545,3 +1545,27 @@ const hasReadAccessByCollection = (
     getAccessGroupCollections(userToken).includes(collectionName)
   );
 };
+
+/**
+ * This handler allows execution to proceed if a ResourceError occurs because of a resource not being found.
+ * This allows authorized requesters to retry request on the working collection which requires explicit authorization
+ *
+ * @param {Error} error
+ * @param {authorizationCases} boolean[] [Contains results from authorization checks that determines whether or not the requester is authorized to access resource]
+ * @returns {null} [Returns null so that the value resolves to null indicating resource was not loaded]
+ */
+const bypassNotFoundResourceErrorIfAuthorized = (params: {
+  error: Error;
+  authorizationCases: boolean[];
+}): null | never => {
+  const { error, authorizationCases } = params;
+  if (
+    !(error instanceof ResourceError) ||
+    (error instanceof ResourceError &&
+      error.name !== ResourceErrorReason.NOT_FOUND) ||
+    !authorizationCases.includes(true)
+  ) {
+    throw error;
+  }
+  return null;
+};

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -333,7 +333,7 @@ export class LearningObjectInteractor {
       dataStore,
       username: authorUsername,
     });
-    const learningObjectID = await this.findLearningObjectIdByAuthorAndName({
+    const learningObjectID = await this.getLearningObjectIdByAuthorAndName({
       dataStore,
       authorId,
       authorUsername,
@@ -371,7 +371,7 @@ export class LearningObjectInteractor {
       dataStore,
       username: authorUsername,
     });
-    const learningObjectID = await this.findReleasedLearningObjectIdByAuthorAndName(
+    const learningObjectID = await this.getReleasedLearningObjectIdByAuthorAndName(
       {
         dataStore,
         authorId,
@@ -434,7 +434,7 @@ export class LearningObjectInteractor {
    * @returns {Promise<string>}
    * @memberof LearningObjectInteractor
    */
-  private static async findLearningObjectIdByAuthorAndName(params: {
+  private static async getLearningObjectIdByAuthorAndName(params: {
     dataStore: DataStore;
     name: string;
     authorId: string;
@@ -468,7 +468,7 @@ export class LearningObjectInteractor {
    * @returns {Promise<string>}
    * @memberof LearningObjectInteractor
    */
-  private static async findReleasedLearningObjectIdByAuthorAndName(params: {
+  private static async getReleasedLearningObjectIdByAuthorAndName(params: {
     dataStore: DataStore;
     name: string;
     authorId: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,9 +12,11 @@ import {
 import { UserDocument } from './user-document';
 import { LearningOutcomeDocument } from './learning-outcome-document';
 import { StandardOutcomeDocument } from './standard-outcome-document';
+import { ServiceToken } from './service-token';
 
 export {
   UserToken,
+  ServiceToken,
   LearningObjectUpdates,
   VALID_LEARNING_OBJECT_UPDATES,
   UserDocument,

--- a/src/types/service-token.ts
+++ b/src/types/service-token.ts
@@ -1,0 +1,3 @@
+export interface ServiceToken {
+  SERVICE_KEY: string;
+}


### PR DESCRIPTION
This PR re-adds the route to fetch a Learning Object's Id (`/learning-objects/:username/:learningObjectName/id`) and refactors authorization logic for this request.

This route is being used by [library-service](https://github.com/Cyber4All/library-service).
