### PR TITLE
Allow `page` and `currPage` as valid page param for backward compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -54,7 +54,7 @@ export class ExpressRouteDriver {
           objects: Partial<LearningObject>[];
         };
         const userToken = req.user;
-        const page = req.query.currPage;
+        const page = req.query.currPage || req.query.page;
         const limit = req.query.limit;
 
         objectResponse = await LearningObjectInteractor.searchObjects({


### PR DESCRIPTION
This PR adds backward compatibility for `page` param used for pagination. The service will now accept `currPage` and `page` (the newer version of the parameter) as valid `page` values.

Closes Cyber4All/clark-client#622