### PR TITLE
Fix request timeout when token is invalid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.9",
+  "version": "2.12.10",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -16,6 +16,7 @@ import * as cors from 'cors';
 import * as cookieParser from 'cookie-parser';
 import * as raven from 'raven';
 import { enforceAuthenticatedAccess, processToken } from '../../middleware';
+import { reportError } from '../SentryConnector';
 
 export class ExpressDriver {
   static app = express();
@@ -58,12 +59,20 @@ export class ExpressDriver {
     );
 
     // Set Validation Middleware
-    this.app.use(enforceAuthenticatedAccess);
-    this.app.use((error: any, req: any, res: any, next: any) => {
-      if (error.name === 'UnauthorizedError') {
-        res.status(401).send('Invalid Access Token');
-      }
-    });
+    this.app.use(
+      enforceAuthenticatedAccess,
+      (error: any, req: any, res: any, next: any) => {
+        if (
+          error.name === 'UnauthorizedError' ||
+          error.name === 'JsonWebTokenError'
+        ) {
+          res.status(401).send('Invalid Access Token');
+        } else {
+          reportError(error);
+          res.send(500);
+        }
+      },
+    );
 
     // Set our authenticated api routes
     this.app.use(

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -49,10 +49,7 @@ export class ExpressDriver {
     // Set up cookie parser
     this.app.use(cookieParser());
 
-    // Handles any errors that may occur when processing the token by passing execution to the next handler. This prevents this error from being passed to other error handlers.
-    this.app.use(processToken, (error: any, req: any, res: any, next: any) =>
-      next(),
-    );
+    this.app.use(processToken);
 
     // Set our public api routes
     this.app.use(


### PR DESCRIPTION
This PR fixes an issue where requests to the service would timeout when the requester sent an invalid token. This was caused by the `proccesToken` middleware throwing an error when trying to parse token which resulted in a `JsonWebTokenError`. This case was not being handled in the error handler used after `enforceAuthenticatedAccess` and therefore the service was at the bottom of its handlers and never responded.

This this PR also removed the :hankey: handler used in the `processToken` middleware. By moving the error handler for `enforceAuthenticatedAccess` inside of `use` statement, errors from `proccessToken` no longer bubble out to the handler that responds with a 401. 

We should update this in the rest of our services that are using this pattern as well.

Closes #235 