### PR TITLE
Fix invalid access on public routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.10",
+  "version": "2.12.11",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -63,20 +63,7 @@ export class ExpressDriver {
     );
 
     // Set Validation Middleware
-    this.app.use(
-      enforceAuthenticatedAccess,
-      (error: any, req: any, res: any, next: any) => {
-        if (
-          error.name === 'UnauthorizedError' ||
-          error.name === 'JsonWebTokenError'
-        ) {
-          res.status(401).send('Invalid Access Token');
-        } else {
-          reportError(error);
-          res.send(500);
-        }
-      },
-    );
+    this.app.use(enforceAuthenticatedAccess);
 
     // Set our authenticated api routes
     this.app.use(

--- a/src/drivers/express/ExpressDriver.ts
+++ b/src/drivers/express/ExpressDriver.ts
@@ -15,7 +15,11 @@ import * as logger from 'morgan';
 import * as cors from 'cors';
 import * as cookieParser from 'cookie-parser';
 import * as raven from 'raven';
-import { enforceAuthenticatedAccess, processToken } from '../../middleware';
+import {
+  enforceAuthenticatedAccess,
+  processToken,
+  handleProcessTokenError,
+} from '../../middleware';
 import { reportError } from '../SentryConnector';
 
 export class ExpressDriver {
@@ -50,7 +54,7 @@ export class ExpressDriver {
     // Set up cookie parser
     this.app.use(cookieParser());
 
-    this.app.use(processToken);
+    this.app.use(processToken, handleProcessTokenError);
 
     // Set our public api routes
     this.app.use(

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,4 +1,4 @@
-import { processToken } from './process-token';
+import { processToken, handleProcessTokenError } from './process-token';
 import { enforceAuthenticatedAccess } from './authenticated-access';
 
-export { processToken, enforceAuthenticatedAccess };
+export { processToken, handleProcessTokenError, enforceAuthenticatedAccess };

--- a/src/middleware/process-token.ts
+++ b/src/middleware/process-token.ts
@@ -1,6 +1,8 @@
 import 'dotenv/config';
 import * as jwt from 'express-jwt';
 import { getToken } from './functions';
+import { NextFunction, Response, Request } from 'express';
+import { reportError } from '../drivers/SentryConnector';
 
 /**
  * Validates and decodes token from cookie or authorization headers. Then sets request.user to decoded token.
@@ -15,3 +17,25 @@ export const processToken = jwt({
   credentialsRequired: false,
   getToken,
 });
+
+/**
+ * Handles errors that may occur when processing the token.
+ * If the token is invalid the handler will call the next handler because its job is solely to attempt to process the token not enforce it
+ * If some other error occurs, the handler reports the error
+ *
+ * @param {Error} error
+ * @param {Request} request
+ * @param {Response} response
+ * @param {NextFunction} next
+ */
+export const handleProcessTokenError = (
+  error: Error,
+  _: Request,
+  __: Response,
+  next: NextFunction,
+) => {
+  if (error.name !== 'JsonWebTokenError') {
+    reportError(error);
+  }
+  next();
+};


### PR DESCRIPTION
This PR fixes a bug introduced in #265 that caused public routes to send a `401` when a user had an invalid token.

These issues were resolved by creating an error handler for the `proccessToken` middleware and moving the error handling for `enforceAuthenticatedAccess` inside of the middleware.