### PR TITLE
Refactor interactor level error handling into a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1660,15 +1660,14 @@ const bypassNotFoundResourceErrorIfAuthorized = (params: {
 };
 
 /**
- * Handles errors by rejecting Promise if handled, otherwise the error is reported and a ServiceError is thrown
+ * Handles errors by throwing error if handled, otherwise the error is reported and a ServiceError is thrown
  *
- * @template T
- * @param {T} error
- * @returns {Promise<T>}
+ * @param {Error} error
+ * @returns {never}
  */
-function handleError<T extends Error>(error: T): Promise<T> {
+function handleError(error: Error): never {
   if (error instanceof ResourceError || error instanceof ServiceError) {
-    return Promise.reject(error);
+    throw error;
   }
   reportError(error);
   throw new ServiceError(ServiceErrorReason.INTERNAL);

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -991,7 +991,7 @@ export class LearningObjectInteractor {
         // Attempt to delete files
         const path = `${user.username}/${obj.id}/`;
         fileManager.deleteAll({ path }).catch(e => {
-          reportError(new Error(`Problem deleting files at ${path}. ${e}`));
+          reportError(e);
         });
         // Update parents' dates
         updateParentsDate({


### PR DESCRIPTION
This PR refactors the error handling logic on `LearningObjectInteractor.ts` to use the `handleError` function and adds better reporting.

Closes #263 