### PR TITLE
Remove bypass logic to display correct status code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.15",
+  "version": "2.12.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.15",
+  "version": "2.12.16",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -114,7 +114,8 @@ export class ExpressRouteDriver {
           res.status(200).send(object.toPlainObject());
         } catch (e) {
           console.error(e);
-          res.status(500).send(e);
+          const { code, message } = mapErrorToResponseData(e);
+          res.status(code).json({message});
         }
       });
 

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1676,12 +1676,22 @@ const bypassNotFoundResourceErrorIfAuthorized = (params: {
   error: Error;
   authorizationCases: boolean[];
 }): null | never => {
-  const { error, authorizationCases } = params;
+
+/**
+ * This handler allows execution to proceed if a ResourceError occurs because of a resource not being found.
+ *
+ * @param {Error} error
+ * @returns {null} [Returns null so that the value resolves to null indicating resource was not loaded]
+ */
+const bypassNotFoundResourceError = ({
+  error,
+}: {
+  error: Error;
+}): null | never => {
   if (
     !(error instanceof ResourceError) ||
     (error instanceof ResourceError &&
-      error.name !== ResourceErrorReason.NOT_FOUND) ||
-    !authorizationCases.includes(true)
+      error.name !== ResourceErrorReason.NOT_FOUND)
   ) {
     throw error;
   }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -238,16 +238,13 @@ export class LearningObjectInteractor {
       let loadWorkingCopies = false;
 
       if (!revision) {
-        const authorizationCases = [true];
-
         learningObject = await this.loadReleasedLearningObjectByAuthorAndName({
           dataStore,
           authorUsername: username,
           learningObjectName,
         }).catch(error =>
-          bypassNotFoundResourceErrorIfAuthorized({
+          bypassNotFoundResourceError({
             error,
-            authorizationCases,
           }),
         );
       }
@@ -1672,10 +1669,18 @@ const hasReadAccessByCollection = (
  * @param {authorizationCases} boolean[] [Contains results from authorization checks that determines whether or not the requester is authorized to access resource]
  * @returns {null} [Returns null so that the value resolves to null indicating resource was not loaded]
  */
-const bypassNotFoundResourceErrorIfAuthorized = (params: {
+const bypassNotFoundResourceErrorIfAuthorized = ({
+  error,
+  authorizationCases,
+}: {
   error: Error;
   authorizationCases: boolean[];
 }): null | never => {
+  if (!authorizationCases.includes(true)) {
+    throw error;
+  }
+  return bypassNotFoundResourceError({ error });
+};
 
 /**
  * This handler allows execution to proceed if a ResourceError occurs because of a resource not being found.

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -238,14 +238,7 @@ export class LearningObjectInteractor {
       let loadWorkingCopies = false;
 
       if (!revision) {
-        const requesterIsAuthor = this.hasReadAccess({
-          userToken,
-          resourceVal: username,
-          authFunction: isAuthorByUsername,
-        }) as boolean;
-        const requesterIsPrivileged =
-          userToken && isPrivilegedUser(userToken.accessGroups);
-        const authorizationCases = [requesterIsAuthor, requesterIsPrivileged];
+        const authorizationCases = [true];
 
         learningObject = await this.loadReleasedLearningObjectByAuthorAndName({
           dataStore,


### PR DESCRIPTION
Removes bypass logic when retrieving learning object data to display in order to display the correct status code for a given learning object.

Closes #274