### PR TITLE
Fix children array being copied to released-objects as an empty array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.13",
+  "version": "2.12.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.13",
+  "version": "2.12.14",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -2032,6 +2032,9 @@ export class MongoDriver implements DataStore {
     let contributors: User[] = [];
     let outcomes: LearningOutcome[] = [];
     let children: LearningObject[] = [];
+    if (Array.isArray(record.children)) {
+      children = record.children.map(id => new LearningObject({ id }));
+    }
 
     // Load Contributors
     if (record.contributors && record.contributors.length) {
@@ -2063,6 +2066,7 @@ export class MongoDriver implements DataStore {
       materials,
       contributors,
       outcomes,
+      children,
     });
 
     return learningObject;


### PR DESCRIPTION
This PR fixes the issue where objects added to the `released-objects` collection would have their `children` property set to an empty array. This issue was caused by the Datastore not setting the children property of a LearningObject when fetching the object.

**Solution**
Map the record's `children` property to LearningObjects with just the `id` property.