### PR TITLE
Remove outbound mapping of id to partial Learning Object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.14",
+  "version": "2.12.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.13",
+  "version": "2.12.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.13",
+  "version": "2.12.14",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.12.14",
+  "version": "2.12.15",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -196,11 +196,7 @@ export async function updateLearningObject(params: {
         isPrivilegedUser(userToken.accessGroups) &&
         cleanUpdates.status === LearningObject.Status.RELEASED
       ) {
-        const object = await dataStore.fetchLearningObject({
-          id,
-          full: true,
-        });
-        await dataStore.addToReleased(object);
+        await releaseLearningObject({ dataStore, id });
       }
     } else {
       return Promise.reject(
@@ -213,6 +209,41 @@ export async function updateLearningObject(params: {
       new Error(`Problem updating learning object ${params.id}. ${e}`),
     );
   }
+}
+
+/**
+ * Releases a LearningObject by adding object to released collection of objects
+ *
+ * FIXME: Once the return type of `fetchLearningObject` is updated to the `Datastore's` schema type,
+ * this function should be updated to not fetch children ids as they should be returned with the document
+ *
+ * @param {DataStore} datastore [Driver for the datastore]
+ * @param {string} id [Id of the LearningObject to be copied]
+ * @returns {Promise<void>}
+ */
+async function releaseLearningObject({
+  dataStore,
+  id,
+}: {
+  dataStore: DataStore;
+  id: string;
+}): Promise<void> {
+  const [object, childIds] = await Promise.all([
+    dataStore.fetchLearningObject({
+      id,
+      full: true,
+    }),
+    dataStore.findChildObjectIds({ parentId: id }),
+  ]);
+  let children: LearningObject[] = [];
+  if (Array.isArray(childIds)) {
+    children = childIds.map(childId => new LearningObject({ id: childId }));
+  }
+  const releasableObject = new LearningObject({
+    ...object.toPlainObject(),
+    children,
+    });
+  return dataStore.addToReleased(releasableObject);
 }
 
 /**

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -2032,9 +2032,6 @@ export class MongoDriver implements DataStore {
     let contributors: User[] = [];
     let outcomes: LearningOutcome[] = [];
     let children: LearningObject[] = [];
-    if (Array.isArray(record.children)) {
-      children = record.children.map(id => new LearningObject({ id }));
-    }
 
     // Load Contributors
     if (record.contributors && record.contributors.length) {


### PR DESCRIPTION
This PR fixes the issue introduced in #276 where child objects would throw validation errors because they were instantiated with just the `id` property and no valid name.

Additionally, this PR replaces the mapping of `id` to Learning Object outbound with a mapping from `childIds` to LearningObject only when Learning Objects are released.