### PR TITLE
Fix Permission Issues on Parent Learning Objects

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,9 +22,6 @@ const runDevelopmentServer = function() {
   return nodemon({
     script: 'dist/app.js',
     ext: 'js',
-  })
-  .once('exit', () => {
-    process.exit();
   });
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.6",
+  "version": "2.14.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.6",
+  "version": "2.14.7",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/Hierarchy/HierarchyInteractor.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyInteractor.ts
@@ -1,0 +1,54 @@
+import { DataStore, ParentLearningObjectQuery } from '../../interfaces/DataStore';
+import { UserToken } from '../../types';
+import { LearningObject } from '../../entity';
+import { toArray, hasReadAccessByCollection, LearningObjectState, handleError } from '../../interactors/LearningObjectInteractor';
+
+/**
+ * Fetches Learning Object's parents
+ *
+ * @returns {Promise<LearningObject[]>} the set of parent Learning Objects
+ */
+export async function fetchParents(params: {
+  dataStore: DataStore;
+  query: ParentLearningObjectQuery;
+  userToken: UserToken;
+  full?: boolean;
+  isRequestingRevision?: boolean;
+}): Promise<LearningObject[]> {
+  try {
+    const { dataStore, query, userToken, full, isRequestingRevision } = params;
+    const status = await dataStore.fetchLearningObjectStatus(query.id);
+    if (status === LearningObject.Status.RELEASED && !isRequestingRevision) {
+      return await dataStore.fetchReleasedParentObjects({
+        query,
+        full,
+      });
+    } else if (userToken || isRequestingRevision) {
+      query.status = toArray(query.status);
+      const [collection, author] = await Promise.all([
+        dataStore.fetchLearningObjectCollection(query.id),
+        dataStore.fetchLearningObjectAuthorUsername(query.id),
+      ]);
+
+      const requesterIsAuthor = userToken.username === author;
+
+      const requesterIsPrivileged = hasReadAccessByCollection(collection, userToken);
+
+      if (requesterIsAuthor) {
+        query.status = LearningObjectState.ALL;
+      } else if (requesterIsPrivileged) {
+        query.status = LearningObjectState.IN_REVIEW;
+      } else {
+        return [];
+      }
+
+      return await params.dataStore.fetchParentObjects({
+        query,
+        full,
+      });
+    }
+    return [];
+  } catch (e) {
+    handleError(e);
+  }
+}

--- a/src/LearningObjects/Hierarchy/HierarchyInteractor.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyInteractor.ts
@@ -2,53 +2,105 @@ import { DataStore, ParentLearningObjectQuery } from '../../interfaces/DataStore
 import { UserToken } from '../../types';
 import { LearningObject } from '../../entity';
 import { toArray, hasReadAccessByCollection, LearningObjectState, handleError } from '../../interactors/LearningObjectInteractor';
+import { ResourceError, ResourceErrorReason } from '../../errors';
 
 /**
- * Fetches Learning Object's parents
+ * Fetches the parents of a Learning Object.
  *
- * @returns {Promise<LearningObject[]>} the set of parent Learning Objects
+ * If the user has privileged access to Learning Objects in the Review Stage
+ * for any collection(s), then those parent Learning Objects will also be returned.
+ * In this case, when there is a released Learning Object and a working copy,
+ * the released copy will be what is returned.
+ *
+ * @returns {Promise<LearningObject[]>} the set of parent Learning Objects.
  */
 export async function fetchParents(params: {
   dataStore: DataStore;
-  query: ParentLearningObjectQuery;
+  learningObjectID: string;
   userToken: UserToken;
   full?: boolean;
-  isRequestingRevision?: boolean;
 }): Promise<LearningObject[]> {
-  try {
-    const { dataStore, query, userToken, full, isRequestingRevision } = params;
-    const status = await dataStore.fetchLearningObjectStatus(query.id);
-    if (status === LearningObject.Status.RELEASED && !isRequestingRevision) {
-      return await dataStore.fetchReleasedParentObjects({
-        query,
-        full,
-      });
-    } else if (userToken || isRequestingRevision) {
-      query.status = toArray(query.status);
-      const [collection, author] = await Promise.all([
-        dataStore.fetchLearningObjectCollection(query.id),
-        dataStore.fetchLearningObjectAuthorUsername(query.id),
-      ]);
+  const { dataStore, learningObjectID, userToken, full } = params;
+  let hasFullAccess = false;
+  let collectionsWithAccess: string[] = [];
+  let requestedByAuthor = false;
+  const [collection, author] = await Promise.all([
+    dataStore.fetchLearningObjectCollection(learningObjectID),
+    dataStore.fetchLearningObjectAuthorUsername(learningObjectID),
+  ]);
 
-      const requesterIsAuthor = userToken.username === author;
-
-      const requesterIsPrivileged = hasReadAccessByCollection(collection, userToken);
-
-      if (requesterIsAuthor) {
-        query.status = LearningObjectState.ALL;
-      } else if (requesterIsPrivileged) {
-        query.status = LearningObjectState.IN_REVIEW;
-      } else {
-        return [];
-      }
-
-      return await params.dataStore.fetchParentObjects({
-        query,
-        full,
-      });
-    }
-    return [];
-  } catch (e) {
-    handleError(e);
+  if (userToken) {
+    hasFullAccess = hasFullReviewStageAccess(userToken.accessGroups);
+    collectionsWithAccess = identifyCollectionAccess(userToken.accessGroups);
+    requestedByAuthor = userToken.username === author;
   }
+
+  if (!requestedByAuthor && !hasFullAccess && collectionsWithAccess.length < 1) {
+    return await dataStore.fetchReleasedParentObjects({
+      query: { id: learningObjectID },
+      full,
+    });
+  } else {
+    return await params.dataStore.fetchParentObjects({
+      query: buildQuery(learningObjectID, requestedByAuthor, hasFullAccess, collectionsWithAccess),
+      full,
+    });
+  }
+}
+
+/**
+ * Creates a ParentLearningObjectQuery based on information about the requester.
+ *
+ * @param learningObjectID the id of the Learning Object to find parents for.
+ * @param requestedByAuthor if the request came from the author of the Learning Object.
+ * @param hasFullAccess if the requester has access to all Review Stage Learning Objects
+ * @param collectionsWithAccess the collections the requester has access to Review Stage
+ * Learning Objects in.
+ * @returns {ParentLearningObjectQuery} the query to pass to the DataStore.
+ */
+function buildQuery(learningObjectID: string, requestedByAuthor: boolean, hasFullAccess: boolean, collectionsWithAccess: string[]) {
+  const query: ParentLearningObjectQuery = {
+    id: learningObjectID,
+  };
+  // IF they are the author THEN return all parent objects
+  if (requestedByAuthor) {
+    query.status = LearningObjectState.ALL;
+  // IF they have review stage access THEN return parent objects in review and released
+  } else if (hasFullAccess) {
+    query.status = [...LearningObjectState.IN_REVIEW, ...LearningObjectState.RELEASED];
+  } else if (collectionsWithAccess.length > 0) {
+    query.status = [...LearningObjectState.IN_REVIEW, ...LearningObjectState.RELEASED];
+    query.collections = collectionsWithAccess;
+  }
+  return query;
+}
+
+/**
+ * Identifies if the requester has access to all Learning Objects that
+ * are in the Review Stage. This applies to admins and editors only.
+ *
+ * @param accessGroups the access groups that a User belongs to.
+ * @returns whether or not the requester has full Review Stage access.
+ */
+function hasFullReviewStageAccess(accessGroups: string[]): boolean {
+  if (!accessGroups) return false;
+  return accessGroups.includes('admin') || accessGroups.includes('editor');
+}
+
+/**
+ * Takes a set of access groups and filters them down to any that conform to the
+ * structure of {role}@{collection}. Then the role and deliminator are stripped
+ * off, and the result is a set of collections that the user has privileged access
+ * to.
+ * @param accessGroups the access groups that a User belongs to.
+ * @returns {string[]} the collections a user has privileged access to.
+ */
+function identifyCollectionAccess(accessGroups: string[]): string[] {
+  const collectionAccessGroups = accessGroups.filter(role => role.includes('@'));
+  const collections = [];
+  for (const group of collectionAccessGroups) {
+    const access = group.split('@');
+    collections.push(access[1]);
+  }
+  return collections;
 }

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -8,15 +8,11 @@ export function initializePublic({ router, dataStore}: { router: Router, dataSto
   const getParents = async (req: Request, res: Response) => {
     try {
       const userToken = req.user;
-      const query = req.query;
-      query.id = req.params.id;
-      const isRequestingRevision = query.revision !== undefined;
 
       const parents = await fetchParents({
-        query,
+        learningObjectID: req.params.id,
         userToken,
         dataStore,
-        isRequestingRevision,
       });
       res.status(200).send(parents.map(obj => obj.toPlainObject()));
     } catch (e) {

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { DataStore } from '../../interfaces/DataStore';
+import { LearningObjectInteractor } from '../../interactors/interactors';
+import { fetchParents } from './HierarchyInteractor';
+
+export function initializePublic({ router, dataStore}: { router: Router, dataStore: DataStore }) {
+  const getParents = async (req: Request, res: Response) => {
+    try {
+      const userToken = req.user;
+      const query = req.query;
+      query.id = req.params.id;
+
+      const parents = await fetchParents({
+        query,
+        userToken,
+        dataStore,
+      });
+      res.status(200).send(parents.map(obj => obj.toPlainObject()));
+    } catch (e) {
+      console.error(e);
+      res.status(500).send(e);
+    }
+  };
+  router.get('/learning-objects/:id/parents', getParents);
+}

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { DataStore } from '../../interfaces/DataStore';
 import { LearningObjectInteractor } from '../../interactors/interactors';
 import { fetchParents } from './HierarchyInteractor';
+import { mapErrorToResponseData } from '../../errors';
 
 export function initializePublic({ router, dataStore}: { router: Router, dataStore: DataStore }) {
   const getParents = async (req: Request, res: Response) => {
@@ -19,8 +20,8 @@ export function initializePublic({ router, dataStore}: { router: Router, dataSto
       });
       res.status(200).send(parents.map(obj => obj.toPlainObject()));
     } catch (e) {
-      console.error(e);
-      res.status(500).send(e);
+      const { code, message } = mapErrorToResponseData(e);
+      res.status(code).json({message});
     }
   };
   router.get('/learning-objects/:id/parents', getParents);

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -9,11 +9,13 @@ export function initializePublic({ router, dataStore}: { router: Router, dataSto
       const userToken = req.user;
       const query = req.query;
       query.id = req.params.id;
+      const isRequestingRevision = query.revision !== undefined;
 
       const parents = await fetchParents({
         query,
         userToken,
         dataStore,
+        isRequestingRevision,
       });
       res.status(200).send(parents.map(obj => obj.toPlainObject()));
     } catch (e) {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -943,11 +943,9 @@ export class MongoDriver implements DataStore {
   /**
    * Fetches Parents of requested Learning Object from working collection if collection not specified
    *
-   * @param {{
-   *     query: ParentLearningObjectQuery;
-   *     collection: string [Collection to query for parent objects from]
-   *   }} params
-   * @returns {Promise<LearningObject[]>}
+   * @param {ParentLearningObjectQuery} query
+   * @param {string} collection Collection to query for parent objects from
+   * @returns {Promise<LearningObject[]>} the set of parent Learning Objects
    * @memberof MongoDriver
    */
     async fetchParentObjects(

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -950,18 +950,16 @@ export class MongoDriver implements DataStore {
    * @returns {Promise<LearningObject[]>}
    * @memberof MongoDriver
    */
-  async fetchParentObjects(params: {
-    query: ParentLearningObjectQuery;
-    full?: boolean;
-    collection?: COLLECTIONS.RELEASED_LEARNING_OBJECTS;
-  }): Promise<LearningObject[]> {
-    const { query, full } = params;
+    async fetchParentObjects(
+      { query, full, collection = COLLECTIONS.LEARNING_OBJECTS }
+      : { query: ParentLearningObjectQuery, full: boolean, collection: COLLECTIONS },
+    ): Promise<LearningObject[]> {
     const mongoQuery: { [index: string]: any } = { children: query.id };
     if (query.status) {
       mongoQuery.status = { $in: query.status };
     }
     let cursor: Cursor<LearningObjectDocument> = await this.db
-      .collection(COLLECTIONS.LEARNING_OBJECTS)
+      .collection(collection)
       .find<LearningObjectDocument>(mongoQuery);
     cursor = this.applyCursorFilters<LearningObjectDocument>(cursor, {
       ...(query as Filters),
@@ -982,7 +980,7 @@ export class MongoDriver implements DataStore {
    */
   async fetchReleasedParentObjects(params: {
     query: ParentLearningObjectQuery;
-    full?: boolean;
+    full: boolean;
   }): Promise<LearningObject[]> {
     return this.fetchParentObjects({
       ...params,

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -126,8 +126,8 @@ export class MongoDriver implements DataStore {
   /**
    * Fetches Learning Object's author's username
    *
-   * @param {string} id
-   * @returns {Promise<string>}
+   * @param {string} id the id of the Learning Object.
+   * @returns {Promise<string>} the username of the author.
    * @memberof MongoDriver
    */
   async fetchLearningObjectAuthorUsername(id: string): Promise<string> {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -16,6 +16,7 @@ import {
   ServiceError,
 } from '../../errors';
 import { LearningObject } from '../../entity';
+import { initializePublic as initializePublicHierarchyRoutes } from '../../LearningObjects/Hierarchy/HierarchyRouteHandler';
 
 // This refers to the package.json that is generated in the dist. See /gulpfile.js for reference.
 // tslint:disable-next-line:no-require-imports
@@ -77,23 +78,7 @@ export class ExpressRouteDriver {
         res.status(code).json({ message });
       }
     });
-
-    router.get('/learning-objects/:id/parents', async (req, res) => {
-      try {
-        const userToken = req.user;
-        const query = req.query;
-        query.id = req.params.id;
-        const parents = await LearningObjectInteractor.fetchParents({
-          query,
-          userToken,
-          dataStore: this.dataStore,
-        });
-        res.status(200).send(parents.map(obj => obj.toPlainObject()));
-      } catch (e) {
-        console.error(e);
-        res.status(500).send(e);
-      }
-    });
+    initializePublicHierarchyRoutes({ router, dataStore: this.dataStore });
 
     router
       .route('/learning-objects/:username/:learningObjectName')

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -39,7 +39,7 @@ import { accessGroups } from '../types/user-token';
 // file size is in bytes
 const MAX_PACKAGEABLE_FILE_SIZE = 100000000;
 
-const LearningObjectState = {
+export const LearningObjectState = {
   UNRELEASED: [
     LearningObject.Status.REJECTED,
     LearningObject.Status.UNRELEASED,
@@ -640,71 +640,6 @@ export class LearningObjectInteractor {
         return new LearningObject({ ...obj.toPlainObject(), children });
       }),
     );
-  }
-
-  /**
-   * Fetches Learning Object's parents
-   *
-   * @static
-   * @param {{
-   *     dataStore: DataStore;
-   *     query: ParentLearningObjectQuery;
-   *     userToken: UserToken;
-   *     full?: boolean;
-   *   }} params
-   * @returns {Promise<LearningObject[]>}
-   * @memberof LearningObjectInteractor
-   */
-  public static async fetchParents(params: {
-    dataStore: DataStore;
-    query: ParentLearningObjectQuery;
-    userToken: UserToken;
-    full?: boolean;
-    revision?: boolean;
-  }): Promise<LearningObject[]> {
-    try {
-      const { dataStore, query, userToken, full, revision } = params;
-      const status = await dataStore.fetchLearningObjectStatus(query.id);
-      if (status === LearningObject.Status.RELEASED && !revision) {
-        return await dataStore.fetchReleasedParentObjects({
-          query,
-          full,
-        });
-      } else if (userToken || revision) {
-        query.status = toArray(query.status);
-        const [collection, author] = await Promise.all([
-          dataStore.fetchLearningObjectCollection(query.id),
-          dataStore.fetchLearningObjectAuthorUsername(query.id),
-        ]);
-        const requesterIsAuthor = this.hasReadAccess({
-          userToken,
-          resourceVal: author,
-          authFunction: isAuthorByUsername,
-        }) as boolean;
-
-        const requesterIsPrivileged = this.hasReadAccess({
-          userToken,
-          resourceVal: collection,
-          authFunction: hasReadAccessByCollection,
-        }) as boolean;
-
-        if (requesterIsAuthor) {
-          query.status = LearningObjectState.ALL;
-        } else if (requesterIsPrivileged) {
-          query.status = LearningObjectState.IN_REVIEW;
-        } else {
-          return [];
-        }
-
-        return await params.dataStore.fetchParentObjects({
-          query,
-          full,
-        });
-      }
-      return [];
-    } catch (e) {
-      handleError(e);
-    }
   }
 
   /**
@@ -1517,7 +1452,7 @@ export function sanitizeFileName(name: string): string {
  * @param {*} value
  * @returns {T[]}
  */
-function toArray<T>(value: any): T[] {
+export function toArray<T>(value: any): T[] {
   if (value == null || value === '') {
     return null;
   }
@@ -1631,7 +1566,7 @@ const isAuthorByUsername = (
  * @param {UserToken} userToken
  * @returns
  */
-const hasReadAccessByCollection = (
+export const hasReadAccessByCollection = (
   collectionName: string,
   userToken: UserToken,
 ) => {
@@ -1690,7 +1625,7 @@ const bypassNotFoundResourceError = ({
  * @param {Error} error
  * @returns {never}
  */
-function handleError(error: Error): never {
+export function handleError(error: Error): never {
   if (error instanceof ResourceError || error instanceof ServiceError) {
     throw error;
   }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1570,7 +1570,7 @@ export const hasReadAccessByCollection = (
   collectionName: string,
   userToken: UserToken,
 ) => {
-  if (!isPrivilegedUser(userToken.accessGroups)) return false;
+  if (!userToken || !isPrivilegedUser(userToken.accessGroups)) return false;
   return (
     isAdminOrEditor(userToken.accessGroups) ||
     getAccessGroupCollections(userToken).includes(collectionName)

--- a/src/interfaces/DataStore.ts
+++ b/src/interfaces/DataStore.ts
@@ -208,6 +208,7 @@ export interface LearningObjectQuery extends ReleasedLearningObjectQuery {
 export interface ParentLearningObjectQuery extends Filters {
   id: string;
   status?: string[];
+  collections?: string[];
 }
 
 export interface QueryCondition {


### PR DESCRIPTION
## Description
**This is still a work in progress**. I would like to get a review of the scenarios described below before they are fully implemented in code. Thanks!

This PR updates the fetchParentObjects method in the datastore to query the released objects collection when that parameter is specified. Previously, there was an optional property declared in the function signature, but it was not being used inside the function.

## Data Access Conditions
The following scenarios use blue nodes and edges to convey public access, and black nodes/edges to convey privileged access.

### Simple Case: Parents Unreleased and Child Released
In this situation, regular users will only see the released child object as a stand-alone Learning Object. Privileged users (such as editors, admins, reviewers, curators) will be able to see that the Learning Object is included in parent objects which happen to be in the Review Stage.

![image](https://user-images.githubusercontent.com/14933100/54441964-252af100-4714-11e9-9ab0-b6e49b197dda.png)

### Child Released, One Parent Released, One Parent Unreleased
This case does not differ much from the above case. All access roles are the same, one of the parents is just now released and can be seen by regular users. Privileged users continue to see both.

![image](https://user-images.githubusercontent.com/14933100/54442049-4be92780-4714-11e9-94c5-e2ddb0c92b43.png)

### Child Released with Revisions, One Parent Released, One Parent Unreleased
Here, a child Learning Object is released, but also has revisions. The relationships mentioned above are maintained, however there is now a node representing the revisions made to the child (labeled as C prime). In this situation, the relationships of the released child transfer to the revised child, but they transfer as uni-directional relationships. This way, the revised child can point to the released parent, but the parent does not directly have a relationship to the child.

![image](https://user-images.githubusercontent.com/14933100/54443450-0417cf80-4717-11e9-9722-873bdaf0db6e.png)


### Child Released with Revisions, One Parent Released with Revisions, One Parent Unreleased
In this case, we extend the above to include revisions to the parent as well as the child (the parent revisions are denoted as P prime). Under these circumstances, the relationship of C' to P' is **transitive**. C' does not have a direct relationship to P', but instead is linked by its relationship to P. On the other hand, P' does have a uni-directional relationship to C, which then has a bi-directional relationship with C'.

![image](https://user-images.githubusercontent.com/14933100/54443780-b51e6a00-4717-11e9-84a9-e89fdaa1ada7.png)

## Impact on Users
The way that this plays out through our UI is that revisions of child objects still show the links to their parents. These parents will only be the released objects, or, in the case where the Learning Objects are going through the review stage for the first time, it will be that original copy.

Say we have a reviewer who is looking at a parent object. They will be able to toggle between the released parent and the revised parent. Both of which will point to the released child. They can then navigate to that released child, and from there toggle between the released and revised child object.

## Dependencies
Closes #280