### PR TITLE
Fix Internal Server Error on Child Modification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.4",
+  "version": "2.14.5",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -1317,11 +1317,11 @@ export class LearningObjectInteractor {
     const { dataStore, children, username, parentName, userToken } = params;
 
     try {
-
-      const parentID = await dataStore.findLearningObject(
-      {authorId: username,
-      name: parentName},
-      );
+      const authorId = await dataStore.findUser(username);
+      const parentID = await dataStore.findLearningObject({
+        authorId,
+        name: parentName,
+      });
       const hasAccess = await hasLearningObjectWriteAccess(userToken, dataStore, parentID);
       if (hasAccess) {
         await dataStore.setChildren(parentID, children);
@@ -1365,10 +1365,11 @@ export class LearningObjectInteractor {
   }) {
     const { dataStore, childId, username, parentName, userToken } = params;
     try {
-      const parentID = await dataStore.findLearningObject(
-        {authorId: username,
-        name: parentName},
-      );
+      const authorId = await dataStore.findUser(username);
+      const parentID = await dataStore.findLearningObject({
+        authorId,
+        name: parentName,
+      });
       const hasAccess = await hasLearningObjectWriteAccess(userToken, dataStore, parentID);
       if (hasAccess) {
         await dataStore.deleteChild(parentID, childId);


### PR DESCRIPTION
Passing the `username` instead of the `authorId` was causing service failure when setting or removing child Learning Objects.