### PR TITLE
Fix cannot filter search by Standard Outcomes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.7",
+  "version": "2.14.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.7",
+  "version": "2.14.8",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/ExpressRouteDriver.ts
+++ b/src/drivers/express/ExpressRouteDriver.ts
@@ -57,16 +57,14 @@ export class ExpressRouteDriver {
         const userToken = req.user;
         const page = req.query.currPage || req.query.page;
         const limit = req.query.limit;
+        const standardOutcomeIDs = req.query.standardOutcomes;
+        const query = Object.assign({}, req.query, { page, limit, standardOutcomeIDs });
 
         objectResponse = await LearningObjectInteractor.searchObjects({
-          dataStore: this.dataStore,
-          library: this.library,
-          query: {
-            ...req.query,
-            page,
-            limit,
-          },
-          userToken,
+            dataStore: this.dataStore,
+            library: this.library,
+            query,
+            userToken,
         });
 
         objectResponse.objects = objectResponse.objects.map(obj =>


### PR DESCRIPTION
The client was sending `standardOutcomes` as a query property, while the server was expecting `standardOutcomeIDs`. In the same fashion that the page and limit properties are transformed by the route handler, I've added a transform step for this property as well.

Closes #281 