### PR TITLE
Remove header offset for outcomes

### DIFF
--- a/src/LearningObjects/PDFKitDriver.ts
+++ b/src/LearningObjects/PDFKitDriver.ts
@@ -89,8 +89,6 @@ export function generatePDF(
       gradientRGB,
       doc,
       title: PDFText.OUTCOMES_TITLE,
-      headerYStart: doc.y - 75,
-      textYStart: doc.y - 70 + 20,
     });
     appendOutcomes(doc, learningObject);
   }


### PR DESCRIPTION
This PR fixes the issue where descriptions would appear to be truncated in the ReadMe PDF. This was a result of the Outcomes header being offset with a negative y value causing the header to appear over the description text.

This was fixed by removing the offset.

Closes #286 