### PR TITLE
Update route to fetch children to send back plain objects instead of constructed Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.9",
+  "version": "2.14.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.14.9",
+  "version": "2.14.10",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/LearningObjectRouteHandler.ts
@@ -159,7 +159,7 @@ export function initializePrivate({
         dataStore,
         id,
       );
-      res.status(200).json(children);
+      res.status(200).json(children.map(c => c.toPlainObject()));
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);
       res.status(code).json({message});


### PR DESCRIPTION
This PR addresses an issue where the route to fetch a Learning Object's children responds with an array of fully-constructed Learning Objects instead of a plain JS object.

Requires Cyber4All/clark-client#767