### PR TITLE
Send full child Learning Objects when requesting a parent Learning Object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -232,7 +232,7 @@ export class LearningObjectInteractor {
         revision,
       } = params;
 
-      const fullChildren = false;
+      const fullChildren = true;
       let loadWorkingCopies = false;
 
       if (!revision) {


### PR DESCRIPTION
This PR updates the service to send full child Learning Objects when the parent Learning Object is requested.

This hotfix is in response to downloads failing for Learning Objects with children.