### PR TITLE
Allow cancellation of unrecorded submissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSubmission/SubmissionDatastore.ts
+++ b/src/LearningObjectSubmission/SubmissionDatastore.ts
@@ -88,12 +88,6 @@ export class SubmissionDatastore {
       })
       .limit(1)
       .toArray();
-    if (!submission || submission.length === 0) {
-      throw new ResourceError(
-        `Recent submission for learning object ${learningObjectId} not found`,
-        ResourceErrorReason.NOT_FOUND,
-      );
-    }
     return submission[0];
   }
 

--- a/src/LearningObjectSubmission/SubmissionDatastore.ts
+++ b/src/LearningObjectSubmission/SubmissionDatastore.ts
@@ -88,6 +88,7 @@ export class SubmissionDatastore {
       })
       .limit(1)
       .toArray();
+    // TODO: Check for submission not found after data is backfilled
     return submission[0];
   }
 

--- a/src/LearningObjectSubmission/SubmissionInteractor.ts
+++ b/src/LearningObjectSubmission/SubmissionInteractor.ts
@@ -109,7 +109,7 @@ export async function cancelSubmission(params: {
     emailVerified: params.emailVerified,
   });
   const submission = await params.dataStore.fetchRecentSubmission(params.learningObjectId);
-  if (submission.cancelDate) {
+  if (submission && submission.cancelDate) {
     throw new ResourceError(
       'This submission has already been canceled',
       ResourceErrorReason.BAD_REQUEST,


### PR DESCRIPTION
This PR removes a check in the `cancelSubmission` function to allow for unrecorded submissions to be canceled. 