### PR TITLE
Allow addition of multiple file meta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.4",
+  "version": "2.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.17.4",
+  "version": "2.18.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -52,7 +52,7 @@ const LearningObjectState = {
  * @param {string} authorUsername [Learning Object's author's username]
  * @param {string} learningObjectId [Id of the Learning Object to add the file metadata to]
  * @param {FileMeta} fileMeta [Object containing metadata about the file]
- * @returns {Promise<string>} [Id of the file metadata]
+ * @returns {Promise<string>} [Id of the added Learning Object file]
  */
 export async function addLearningObjectFile({
   dataStore,
@@ -96,14 +96,13 @@ export async function addLearningObjectFile({
 
 /**
  * Adds or updates Learning Object mutliple file metadata
- * *** Only the author of Learning Object, admins, and editors are allowed to add file metadata to a Learning Object ***
  * @export
  * @param {DataStore} dataStore [Driver for datastore]
  * @param {UserToken} requester [Object containing information about the requester]
  * @param {string} authorUsername [Learning Object's author's username]
  * @param {string} learningObjectId [Id of the Learning Object to add the file metadata to]
  * @param {FileMeta[]} fileMeta [Object containing metadata about the file]
- * @returns {Promise<string>} [Id of the file metadata]
+ * @returns {Promise<string[]>} [Ids of the added Learning Object files]
  */
 export async function addLearningObjectFiles({
   dataStore,

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -72,13 +72,8 @@ export async function addLearningObjectFile({
     const isAdminOrEditor = requesterIsAdminOrEditor(requester);
     authorizeRequest([isAuthor, isAdminOrEditor]);
     validateRequestParams({
-      params: [
-        fileMeta.name,
-        fileMeta.fileType,
-        fileMeta.url,
-        fileMeta.size,
-      ],
-      mustProvide: ['name', 'fileType', 'url', 'size'],
+      params: [fileMeta.name, fileMeta.url, fileMeta.size],
+      mustProvide: ['name', 'url', 'size'],
     });
     const loFile: LearningObject.Material.File = generateLearningObjectFile(
       fileMeta,
@@ -144,12 +139,14 @@ export async function addLearningObjectFiles({
 function generateLearningObjectFile(
   file: FileMeta,
 ): LearningObject.Material.File {
+  const extension = file.name.split('.').pop();
+  const fileType = file.fileType || '';
   const learningObjectFile: Partial<LearningObject.Material.File> = {
+    extension,
+    fileType,
     url: file.url,
     date: Date.now().toString(),
     name: file.name,
-    fileType: file.fileType,
-    extension: file.extension,
     fullPath: file.fullPath,
     size: +file.size,
     packageable: isPackageable(+file.size),

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -76,10 +76,9 @@ export async function addLearningObjectFile({
         fileMeta.name,
         fileMeta.fileType,
         fileMeta.url,
-        fileMeta.date,
         fileMeta.size,
       ],
-      mustProvide: ['name', 'fileType', 'url', 'date', 'size'],
+      mustProvide: ['name', 'fileType', 'url', 'size'],
     });
     const loFile: LearningObject.Material.File = generateLearningObjectFile(
       fileMeta,
@@ -148,7 +147,7 @@ function generateLearningObjectFile(
 ): LearningObject.Material.File {
   const learningObjectFile: Partial<LearningObject.Material.File> = {
     url: file.url,
-    date: file.date,
+    date: Date.now().toString(),
     name: file.name,
     fileType: file.fileType,
     extension: file.extension,

--- a/src/LearningObjects/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/LearningObjectRouteHandler.ts
@@ -173,16 +173,26 @@ export function initializePrivate({
       const requester: UserToken = req.user;
       const authorUsername: string = req.params.username;
       const learningObjectId: string = req.params.learningObjectId;
-      const fileMeta: FileMeta = req.body.fileMeta;
-
-      const fileMetaId = await LearningObjectInteractor.addLearningObjectFile({
-        dataStore,
-        requester,
-        authorUsername,
-        learningObjectId,
-        fileMeta,
-      });
-      res.status(200).send(fileMetaId);
+      const fileMeta: FileMeta | FileMeta[] = req.body.fileMeta;
+      let fileMetaId;
+      if (Array.isArray(fileMeta)) {
+        fileMetaId = await LearningObjectInteractor.addLearningObjectFiles({
+          dataStore,
+          requester,
+          authorUsername,
+          learningObjectId,
+          fileMeta,
+        });
+      } else {
+        fileMetaId = await LearningObjectInteractor.addLearningObjectFile({
+          dataStore,
+          requester,
+          authorUsername,
+          learningObjectId,
+          fileMeta,
+        });
+      }
+      res.status(200).send({ fileMetaId });
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);
       res.status(code).json({ message });

--- a/src/LearningObjects/typings/index.ts
+++ b/src/LearningObjects/typings/index.ts
@@ -1,7 +1,6 @@
 export interface FileMeta {
   name: string;
   fileType: string;
-  extension: string;
   url: string;
   size: number;
   fullPath?: string;

--- a/src/LearningObjects/typings/index.ts
+++ b/src/LearningObjects/typings/index.ts
@@ -3,7 +3,6 @@ export interface FileMeta {
   fileType: string;
   extension: string;
   url: string;
-  date: string;
   size: number;
   fullPath?: string;
 }


### PR DESCRIPTION
This PR updates the POST route for `/materials/files` to allow client to add metadata for multiple files with a single request.