### PR TITLE
Remove Authorization Error Reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2-1",
+  "version": "2.18.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/express/middleware/authenticated-access.ts
+++ b/src/drivers/express/middleware/authenticated-access.ts
@@ -42,7 +42,7 @@ function decodeToken(req: Request) {
     const token = getToken(req);
     user = jwt.verify(token, process.env.KEY);
   } catch (e) {
-    if (e.name !== 'UnauthorizedError') {
+    if (e.name !== 'UnauthorizedError' && e.name !== 'JsonWebTokenError') {
       reportError(e);
     }
   }

--- a/src/drivers/express/middleware/process-token.ts
+++ b/src/drivers/express/middleware/process-token.ts
@@ -34,7 +34,7 @@ export const handleProcessTokenError = (
   __: Response,
   next: NextFunction,
 ) => {
-  if (error.name !== 'JsonWebTokenError') {
+  if (error.name !== 'UnauthorizedError' && error.name !== 'JsonWebTokenError') {
     reportError(error);
   }
   next();


### PR DESCRIPTION
This PR addresses story #153
https://app.clubhouse.io/clarkcan/story/153/remove-authorization-error-reports

The purpose of this PR is to prevent error reporting to Sentry in the case of an invalid token. 
When replicating the error, I found that both `UnauthorizedError` and `JsonWebTokenError` were being thrown when attempting to access the service with an invalid token. I simply added both of these to the conditional. If the produced error does not match either of these types, the middleware reports the error to Sentry. 

This needs to be replicated in all services before resolving the clubhouse story.