### PR TITLE
Create Singleton Mongo Connection Host

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2",
+  "version": "2.18.2-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2-1",
+  "version": "2.18.2-2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import {
 } from './shared/interfaces/interfaces';
 import * as dotenv from 'dotenv';
 import { LibraryDriver } from './drivers/LibraryDriver';
+import { MongoConnector } from './shared/Mongo/MongoConnector';
 dotenv.config();
 // ----------------------------------------------------------------------------------
 // Initializations
@@ -37,6 +38,19 @@ switch (process.env.NODE_ENV) {
 }
 const fileManager: FileManager = new S3Driver();
 const library: LibraryCommunicator = new LibraryDriver();
-MongoDriver.build(dburi).then(dataStore => {
+
+/**
+ * This is written as a self-invoking function to enable the syntactic sugar
+ * of async-await.
+ * FIXME: Both the MongoConnector and the MongoDriver are called here. This
+ * enables us to leave the legacy code (MongoDriver) running as-is while we
+ * begin to work on building and refactoring modules in this service.
+ * Eventually, the MongoDriver should be completely removed, along with the
+ * call to its build function here.
+ */
+(async () => {
+  await MongoConnector.open(dburi);
+  const dataStore = await MongoDriver.build(dburi);
   ExpressDriver.start(dataStore, fileManager, library);
-});
+})();
+

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -42,6 +42,7 @@ import {
 import { reportError } from './SentryConnector';
 import { LearningObject, LearningOutcome, User } from '../shared/entity';
 import { Submission } from '../LearningObjectSubmission/types/Submission';
+import { MongoConnector } from '../shared/Mongo/MongoConnector';
 
 export enum COLLECTIONS {
   USERS = 'users',
@@ -69,47 +70,15 @@ export class MongoDriver implements DataStore {
 
   static async build(dburi: string) {
     const driver = new MongoDriver();
-    await driver.connect(dburi);
+    // FIXME: This is here to prevent existing tests that use this class from
+    // breaking with the introduction of the MongoConnector
+    if (!MongoConnector.client()) {
+      await MongoConnector.open(dburi);
+    }
+    driver.mongoClient = MongoConnector.client();
+    driver.db = driver.mongoClient.db();
     await driver.initializeModules();
     return driver;
-  }
-
-  /**
-   * Connect to the database. Must be called before any other functions.
-   * @async
-   *
-   * NOTE: This function will attempt to connect to the database every
-   *       time it is called, but since it assigns the result to a local
-   *       variable which can only ever be created once, only one
-   *       connection will ever be active at a time.
-   *
-   * TODO: Verify that connections are automatically closed
-   *       when they no longer have a reference.
-   *
-   * @param {string} dbIP the host and port on which mongodb is running
-   */
-  async connect(dbURI: string, retryAttempt?: number): Promise<void> {
-    try {
-      this.mongoClient = await MongoClient.connect(dbURI);
-      this.db = this.mongoClient.db();
-    } catch (e) {
-      if (!retryAttempt) {
-        this.connect(dbURI, 1);
-      } else {
-        return Promise.reject(
-          'Problem connecting to database at ' + dbURI + ':\n\t' + e,
-        );
-      }
-    }
-  }
-
-  /**
-   * Close the database. Note that this will affect all services
-   * and scripts using the database, so only do this if it's very
-   * important or if you are sure that *everything* is finished.
-   */
-  disconnect(): void {
-    this.mongoClient.close();
   }
 
   /**

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -81,6 +81,10 @@ export class MongoDriver implements DataStore {
     return driver;
   }
 
+  async disconnect() {
+    return MongoConnector.disconnect();
+  }
+
   /**
    * Initializes module stores
    *

--- a/src/shared/Mongo/MongoConnector.ts
+++ b/src/shared/Mongo/MongoConnector.ts
@@ -60,7 +60,7 @@ export class MongoConnector {
    * and scripts using the database, so only do this if it's very
    * important or if you are sure that *everything* is finished.
    */
-  disconnect(): void {
-    MongoConnector.mongoClient.close();
+  static disconnect(): Promise<void> {
+    return MongoConnector.mongoClient.close();
   }
 }

--- a/src/shared/Mongo/MongoConnector.ts
+++ b/src/shared/Mongo/MongoConnector.ts
@@ -1,0 +1,66 @@
+import { MongoClient, Db } from 'mongodb';
+import { reportError } from '../../drivers/SentryConnector';
+import { ServiceError, ServiceErrorReason } from '../errors';
+
+export class MongoConnector {
+  private static mongoClient: MongoClient;
+
+  /**
+   * Opens a new connection to the database that can be shared via
+   * the getConnection function.
+   * @param dburi the URI of the MongoDB instance to connect to.
+   */
+  static async open(dburi: string): Promise<void> {
+    try {
+      if (!MongoConnector.mongoClient) {
+        const driver = new MongoConnector();
+        await driver.connect(dburi);
+      } else {
+        return Promise.reject(
+          new Error('There can be only one MongoClient'),
+        );
+      }
+    } catch (error) {
+      reportError(error);
+      return Promise.reject(
+        new ServiceError(
+          ServiceErrorReason.INTERNAL,
+        ),
+      );
+    }
+  }
+
+  /**
+   * Retrieves the client with an open connection to the database.
+   */
+  static client(): MongoClient {
+    return this.mongoClient;
+  }
+
+  /**
+   * Connect to the database. Must be called before any other functions.
+   * @param {string} dbIP the host and port on which mongodb is running
+   */
+  private async connect(dbURI: string, retryAttempt?: number): Promise<void> {
+    try {
+      MongoConnector.mongoClient = await MongoClient.connect(dbURI);
+    } catch (e) {
+      if (!retryAttempt) {
+        this.connect(dbURI, 1);
+      } else {
+        return Promise.reject(
+          'Problem connecting to database at ' + dbURI + ':\n\t' + e,
+        );
+      }
+    }
+  }
+
+  /**
+   * Close the database. Note that this will affect all services
+   * and scripts using the database, so only do this if it's very
+   * important or if you are sure that *everything* is finished.
+   */
+  disconnect(): void {
+    MongoConnector.mongoClient.close();
+  }
+}

--- a/src/shared/Mongo/MongoConnector.ts
+++ b/src/shared/Mongo/MongoConnector.ts
@@ -39,7 +39,7 @@ export class MongoConnector {
 
   /**
    * Connect to the database. Must be called before any other functions.
-   * @param {string} dbIP the host and port on which mongodb is running
+   * @param {string} dbURI the host and port on which mongodb is running
    */
   private async connect(dbURI: string, retryAttempt?: number): Promise<void> {
     try {

--- a/src/shared/Mongo/MongoConnector.ts
+++ b/src/shared/Mongo/MongoConnector.ts
@@ -43,7 +43,7 @@ export class MongoConnector {
    */
   private async connect(dbURI: string, retryAttempt?: number): Promise<void> {
     try {
-      MongoConnector.mongoClient = await MongoClient.connect(dbURI);
+      MongoConnector.mongoClient = await new MongoClient(dbURI, {reconnectTries: 1).connect();
     } catch (e) {
       if (!retryAttempt) {
         this.connect(dbURI, 1);

--- a/src/shared/Mongo/MongoConnector.ts
+++ b/src/shared/Mongo/MongoConnector.ts
@@ -43,15 +43,11 @@ export class MongoConnector {
    */
   private async connect(dbURI: string, retryAttempt?: number): Promise<void> {
     try {
-      MongoConnector.mongoClient = await new MongoClient(dbURI, {reconnectTries: 1).connect();
+      MongoConnector.mongoClient = await new MongoClient(dbURI, { reconnectTries: 1 }).connect();
     } catch (e) {
-      if (!retryAttempt) {
-        this.connect(dbURI, 1);
-      } else {
-        return Promise.reject(
-          'Problem connecting to database at ' + dbURI + ':\n\t' + e,
-        );
-      }
+      return Promise.reject(
+        'Problem connecting to database at ' + dbURI + ':\n\t' + e,
+      );
     }
   }
 

--- a/src/shared/interfaces/DataStore.ts
+++ b/src/shared/interfaces/DataStore.ts
@@ -12,11 +12,6 @@ export interface DataStore
     LearningObjectStatDatastore,
     CollectionDataStore {
   /*
-   * Datastore Connection Management
-   */
-  connect(dburi: string): Promise<void>;
-  disconnect(): void;
-  /*
    * CREATE Operations
    */
 


### PR DESCRIPTION
This PR takes the pattern of using a Singleton to hold an instance of `MongoClient` that independent modules within the service can share. This was introduced in other services, however there is a slight tweak here.

In order to prevent refactoring of the current `MongoDriver` and keep tests green, I still have the `MongoDriver` run its build method as normal in the `app.ts`. In that build method (this is to keep tests passing) I added a small conditional that if the `MongoConnector` hasn't opened its connection yet, the `MongoDriver` will ask it to do so - then proceed as normal.

I have left FIXMEs in the code on the areas that we should make sure we go back and update after we've continued down the road of refactoring.