### PR TITLE
Speed Up Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,19 +26,6 @@ jobs:
           paths: 
               - ./package.json
               - ./deploy.sh
-  integration-test:
-    <<: *defaults
-    steps:
-      - attach_workspace: 
-          at: ~/learning-object-service
-      - setup_remote_docker
-      - run:
-          name: Pull Image
-          command: docker pull "${DOCKER_USER_ORG}/learning-object-service:${CIRCLE_SHA1}"
-      - run:
-          name: Run Integration Test
-          command: |
-            echo docker run -it learning-object-service:$CIRCLE_SHA1 npm test
 
   deploy-production:
     <<: *defaults
@@ -71,9 +58,6 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - integration-test:
-          requires:
-            - build
 
   build-test-and-deploy-production:
     jobs:
@@ -81,15 +65,9 @@ workflows:
           filters:
             branches:
               only: /master/
-      - integration-test:
-          requires:
-            - build
-          filters:
-            branches:
-              only: /master/
       - deploy-production:
           requires:
-            - integration-test
+            - build
           filters:
             branches:
               only: /master/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2-2",
+  "version": "2.18.2-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.2-2",
+  "version": "2.18.2-3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/Changelogs/ChangelogDatastore.spec.ts
+++ b/src/Changelogs/ChangelogDatastore.spec.ts
@@ -52,8 +52,5 @@ describe('MongoDriver', () => {
     });
   });
 
-  afterAll(() => {
-    driver.disconnect();
-    console.log('Disconnected from Database');
-  });
+  afterAll(() => driver.disconnect());
 });

--- a/src/LearningObjectStats/LearningObjectStatsRouteHandler.spec.ts
+++ b/src/LearningObjectStats/LearningObjectStatsRouteHandler.spec.ts
@@ -29,7 +29,5 @@ describe('LearningObjectStatsRouteHandler', () => {
             });
         });
     });
-    afterAll(() => {
-        dataStore.disconnect();
-    });
+    afterAll(() => dataStore.disconnect());
 });

--- a/src/LearningObjects/LearningObjectRouteHandler.spec.ts
+++ b/src/LearningObjects/LearningObjectRouteHandler.spec.ts
@@ -109,8 +109,5 @@ describe('LearningObjectRouteHandler', () => {
                 });
         });
     });
-    afterAll(() => {
-        dataStore.disconnect();
-        console.log('Disconnected from Database');
-    });
+    afterAll(() => dataStore.disconnect());
 });

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
@@ -107,9 +107,6 @@ describe('LearningOutcomeRouteHandler', () => {
         });
     });
   });
-  afterAll(() => {
-    driver.disconnect();
-    console.log('Disconnected from Database');
-  });
+  afterAll(() => driver.disconnect());
 });
 

--- a/src/drivers/MongoDriver.spec.ts
+++ b/src/drivers/MongoDriver.spec.ts
@@ -64,8 +64,5 @@ describe('MongoDriver', () => {
     });
   });
 
-  afterAll(() => {
-    driver.disconnect();
-    console.log('Disconnected from Database');
-  });
+  afterAll(() => driver.disconnect());
 });


### PR DESCRIPTION
This speeds up tests by returning the result of the `MongoDriver` disconnect function so that teardown doesn't hang as long. It also removes the integration test stage from CircleCI that was not actually running anything useful.

The test runner still hangs quite a bit after running teardown for Mongo and Node. I wasn't able to figure out why, so we'll need to keep working on that.