### PR TITLE
Use correct status code when not sending back response body

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.3-3",
+  "version": "2.18.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.3-3",
+  "version": "2.18.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.spec.ts
@@ -98,10 +98,10 @@ describe('LearningOutcomeRouteHandler', () => {
   });
 
   describe('DELETE /learning-objects/:id/learning-outcomes/:outcomeId', () => {
-    it('should return a status of 200', done => {
+    it('should return a status of 204', done => {
       request
         .delete('/learning-objects/:id/learning-outcomes/:outcomeId')
-        .expect(200)
+        .expect(204)
         .then(res => {
           done();
         });

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.ts
@@ -77,7 +77,7 @@ export function initialize({
         user,
         id,
       });
-      res.sendStatus(200);
+      res.sendStatus(204);
     } catch (e) {
       console.error(e);
       res.status(500).send(e);


### PR DESCRIPTION
This PR fixes an issue where the service would send back a `200` status code, meaning a response body was present, when the status code should have in fact been a `204` status code to indicate no response body is attached.

This fix is in relation to the builder showing error messages when deleting outcomes even though the request was successful. Since the service sent back a `200` the `HttpClient` module would try and parse the body as JSON which threw client errors because no response body existed. Sending back a `204` tells the client there is no response body, so the `HttpClient` module does not attempt to parse it.

![image 5](https://user-images.githubusercontent.com/15234476/58512864-25138c80-816c-11e9-9b98-51646e7399d6.png)
