### PR TITLE
Test Updates that Release Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.4",
+  "version": "2.18.4-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.4",
+  "version": "2.18.4-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectRouteHandler.spec.ts
+++ b/src/LearningObjects/LearningObjectRouteHandler.spec.ts
@@ -103,10 +103,7 @@ describe('LearningObjectRouteHandler', () => {
             });
             describe('and the requester is an editor', () => {
                 it('should update the requested Learning Object and return a status of 200', done => {
-                    const editorToken = generateToken({
-                        ...MOCK_OBJECTS.USERTOKEN,
-                        accessGroups: ['editor'],
-                    });
+                    const editorToken = generateToken(MOCK_OBJECTS.USERTOKEN_EDITOR);
                     request
                         .patch(`/learning-objects/${testObjectID}`)
                         .set('Authorization', `Bearer ${editorToken}`)


### PR DESCRIPTION
This PR adds test cases to assert that when a Learning Object update request is made by an editor or an admin with `status: released` included, the service responds with a 200 OK.