### PR TITLE
Create Publishing Module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.4-1",
+  "version": "2.18.4-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.18.4-1",
+  "version": "2.18.4-2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/Publishing/ElasticMongoReleaseRequestDuplicator.ts
+++ b/src/LearningObjects/Publishing/ElasticMongoReleaseRequestDuplicator.ts
@@ -9,7 +9,7 @@ import { ElasticSearchPublishingGateway } from './ElasticSearchPublishingGateway
  * running in "dark mode", where we index data into it but do not read data
  * out of it.
  */
-export class ReleaseRequestDuplicator implements PublishingDataStore {
+export class ElasticMongoReleaseRequestDuplicator implements PublishingDataStore {
   elasticSearchStore: PublishingDataStore;
   constructor(private mongoStore: PublishingDataStore) {
     this.elasticSearchStore = new ElasticSearchPublishingGateway();

--- a/src/LearningObjects/Publishing/ElasticSearchPublishingGateway.ts
+++ b/src/LearningObjects/Publishing/ElasticSearchPublishingGateway.ts
@@ -1,0 +1,17 @@
+import { PublishingDataStore } from './interactor';
+import { LearningObject } from '../../shared/entity';
+import * as request from 'request-promise';
+
+const INDEX_LOCATION = `${process.env.ELASTICSEARCH_DOMAIN}/released-objects`;
+
+/**
+ * Sends a PUT request to ElasticSearch to index the Learning Object at a
+ * specific ID. Here we use the id already associated with the Learning Object
+ * for ease of lookup.
+ */
+export class ElasticSearchPublishingGateway implements PublishingDataStore {
+  async addToReleased(releasableObject: LearningObject): Promise<void> {
+    const URI = `${INDEX_LOCATION}/_doc/${releasableObject.id}`;
+    await request.put(URI, { body: releasableObject });
+  }
+}

--- a/src/LearningObjects/Publishing/ReleaseRequestDuplicator.ts
+++ b/src/LearningObjects/Publishing/ReleaseRequestDuplicator.ts
@@ -1,0 +1,33 @@
+import { PublishingDataStore } from './interactor';
+import { LearningObject } from '../../shared/entity';
+import { reportError } from '../../shared/SentryConnector';
+import { ElasticSearchPublishingGateway } from './ElasticSearchPublishingGateway';
+
+/**
+ * This class is an abstraction point that allows us to use Mongo and
+ * ElasticSearch side-by-side. It is written with the intent of ElasticSearch
+ * running in "dark mode", where we index data into it but do not read data
+ * out of it.
+ */
+export class ReleaseRequestDuplicator implements PublishingDataStore {
+  elasticSearchStore: PublishingDataStore;
+  constructor(private mongoStore: PublishingDataStore) {
+    this.elasticSearchStore = new ElasticSearchPublishingGateway();
+  }
+
+  /**
+   * Tries to index the Learning Object into ElasticSearch, then proceeds
+   * to make the call to Mongo as normal. If the request to ElasticSearch
+   * fails, we report the error and proceed as if nothing happened.
+   *
+   * @param releasableObject the Learning Object that should be released
+   */
+  async addToReleased(releasableObject: LearningObject): Promise<void> {
+    try {
+      await this.elasticSearchStore.addToReleased(releasableObject);
+    } catch (e) {
+      reportError(e);
+    }
+    return this.mongoStore.addToReleased(releasableObject);
+  }
+}

--- a/src/LearningObjects/Publishing/index.ts
+++ b/src/LearningObjects/Publishing/index.ts
@@ -1,0 +1,17 @@
+import { releaseLearningObject, PublishingDataStore } from './interactor';
+import { LearningObject } from '../../shared/entity';
+import { ReleaseRequestDuplicator } from './ReleaseRequestDuplicator';
+import { UserToken } from '../../shared/types';
+
+// FIXME: Replace with direct export of ElasticSearchPublishingGateway#releaseLearningObject
+// once we do away with the released-objects collection in Mongo
+const setupElasticToggle = ({ userToken, dataStore, releasableObject }: {
+  userToken: UserToken,
+  dataStore: PublishingDataStore;
+  releasableObject: LearningObject;
+}) => {
+  const toggle = new ReleaseRequestDuplicator(dataStore);
+  releaseLearningObject({ userToken, dataStore: toggle, releasableObject });
+};
+
+export { setupElasticToggle as releaseLearningObject };

--- a/src/LearningObjects/Publishing/index.ts
+++ b/src/LearningObjects/Publishing/index.ts
@@ -1,6 +1,6 @@
 import { releaseLearningObject, PublishingDataStore } from './interactor';
 import { LearningObject } from '../../shared/entity';
-import { ReleaseRequestDuplicator } from './ReleaseRequestDuplicator';
+import { ElasticMongoReleaseRequestDuplicator } from './ElasticMongoReleaseRequestDuplicator';
 import { UserToken } from '../../shared/types';
 
 // FIXME: Replace with direct export of ElasticSearchPublishingGateway#releaseLearningObject
@@ -10,7 +10,7 @@ const setupElasticToggle = ({ userToken, dataStore, releasableObject }: {
   dataStore: PublishingDataStore;
   releasableObject: LearningObject;
 }) => {
-  const toggle = new ReleaseRequestDuplicator(dataStore);
+  const toggle = new ElasticMongoReleaseRequestDuplicator(dataStore);
   releaseLearningObject({ userToken, dataStore: toggle, releasableObject });
 };
 

--- a/src/LearningObjects/Publishing/interactor.ts
+++ b/src/LearningObjects/Publishing/interactor.ts
@@ -1,0 +1,26 @@
+import { DataStore } from '../../shared/interfaces/DataStore';
+import { LearningObject } from '../../shared/entity';
+import { ReleaseRequestDuplicator } from './ReleaseRequestDuplicator';
+import { ResourceError, ResourceErrorReason } from '../../shared/errors';
+import { isAdminOrEditor } from '../../shared/AuthorizationManager';
+import { UserToken } from '../../shared/types';
+
+export interface PublishingDataStore {
+    addToReleased(releasableObject: LearningObject): Promise<void>;
+}
+
+/**
+ * If the user is an admin or editor (the only roles that can release a Learning Object),
+ * then request the data store marks the Learning Object as released. Otherwise, throw a
+ * ResourceError.
+ */
+export async function releaseLearningObject({ userToken, dataStore, releasableObject }: {
+    userToken: UserToken,
+    dataStore: PublishingDataStore;
+    releasableObject: LearningObject;
+}): Promise<void> {
+    if (isAdminOrEditor(userToken.accessGroups)) {
+        return dataStore.addToReleased(releasableObject);
+    }
+    throw new ResourceError(`${userToken.username} does not have access to release this Learning Object`, ResourceErrorReason.INVALID_ACCESS);
+}

--- a/src/LearningObjects/Publishing/interactor.ts
+++ b/src/LearningObjects/Publishing/interactor.ts
@@ -1,6 +1,6 @@
 import { DataStore } from '../../shared/interfaces/DataStore';
 import { LearningObject } from '../../shared/entity';
-import { ReleaseRequestDuplicator } from './ReleaseRequestDuplicator';
+import { ElasticMongoReleaseRequestDuplicator } from './ElasticMongoReleaseRequestDuplicator';
 import { ResourceError, ResourceErrorReason } from '../../shared/errors';
 import { isAdminOrEditor } from '../../shared/AuthorizationManager';
 import { UserToken } from '../../shared/types';


### PR DESCRIPTION
This PR moves the logic of publishing a LearningObject (aka "releasing") to its own module, rather than including it inside of the existing `LearningObjectInteractor` and `MongoDriver`.

### Approach
The Publishing module exports an anonymous function that instantiates a new `ReleaseRequestDuplicator` (I'm not sold on the name here, so any suggestions are welcome) and replaces the `dataStore` provided to the interactor function, `releaseLearningObject`, with an instance of this class instead.

Then internally, the `ReleaseRequestDuplicator` makes a request to index the Learning Object into ElasticSearch before proceeding as normal to call `addToReleased` on the `MongoDriver` that is hidden behind service-wide `DataStore` interface.

### The Name Choice
I chose *Publishing* module based on a conversation we had about Domain Driven Design models for our system where we discussed a Publishing Department. I thought that this Publishing Department would make a good standalone service one day, and so a good place to start would be with a module inside of the Learning Object Service right now.

### Other Changes
Additionally, as a side-effect of working through the release authorization again, I noticed that we were using `AuthorizationManager#isPrivilegedUser` instead of `AuthorizationManager#isAdminOrEditor` when checking if a user was able to release a Learning Object. This meant that in the case that an author of a Learning Object for a collection was also a reviewer in that same collection, they could release their own Learning Object.