### PR TITLE
Catch and handle EntityErrors on Submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSubmission/SubmissionInteractor.ts
+++ b/src/LearningObjectSubmission/SubmissionInteractor.ts
@@ -6,6 +6,7 @@ import { Submission } from './types/Submission';
 import { authorizeSubmissionRequest } from './AuthorizationManager';
 import { UserToken } from '../shared/types';
 import { ResourceError, ResourceErrorReason } from '../shared/errors';
+import { EntityError } from '../shared/entity/errors/entity-error';
 
 /**
  * Submit a learning object to a collection
@@ -35,8 +36,14 @@ export async function submitForReview(params: {
     id: params.learningObjectId,
     full: true,
   });
-  // tslint:disable-next-line:no-unused-expression
-  new SubmittableLearningObject(object);
+  try {
+    // tslint:disable-next-line:no-unused-expression
+    new SubmittableLearningObject(object);
+  } catch (error) {
+    if (error instanceof EntityError) {
+      throw new ResourceError(error.message, ResourceErrorReason.BAD_REQUEST);
+    } else throw error;
+  }
   await params.dataStore.submitLearningObjectToCollection(
     params.user.username,
     params.learningObjectId,


### PR DESCRIPTION
This PR adds a catch block that transforms errors when instantiating a `SubmittableLearningObject` to `ResourceErrors` to avoid sending back a 500 error for a bad submission request.