### PR TITLE
Add Forbidden Error Response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.19.1-1",
+  "version": "2.19.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.19.1-1",
+  "version": "2.19.1-2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -21,6 +21,7 @@ export class ServiceError extends Error {
  * The reasons for which a ResourceError may be thrown.
  */
 export enum ResourceErrorReason {
+  FORBIDDEN = 'Forbidden',
   INVALID_ACCESS = 'InvalidAccess',
   NOT_FOUND = 'NotFound',
   BAD_REQUEST = 'BadRequest',
@@ -59,6 +60,9 @@ export function mapErrorToResponseData(error: Error): { code: number, message: s
       break;
     case ResourceErrorReason.INVALID_ACCESS:
       status.code = 401;
+      break;
+    case ResourceErrorReason.FORBIDDEN:
+      status.code = 403;
       break;
     case ResourceErrorReason.NOT_FOUND:
       status.code = 404;


### PR DESCRIPTION
This PR adds the Forbidden error type as a response, allowing our service to differentiate between "I do not have your credentials" and "I know who you are, but you can't do this".