### PR TITLE
Remove false positive tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.20.0",
+  "version": "2.20.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.20.0",
+  "version": "2.20.0-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSubmission/SubmissionInteractor.spec.ts
+++ b/src/LearningObjectSubmission/SubmissionInteractor.spec.ts
@@ -1,100 +1,24 @@
-import { submitForReview, cancelSubmission } from './SubmissionInteractor';
+import { cancelSubmission } from './SubmissionInteractor';
 import {
   MOCK_OBJECTS,
   SUBMITTABLE_LEARNING_OBJECT,
 } from '../tests/mocks';
 import { DataStore } from '../shared/interfaces/DataStore';
 import { MockDataStore } from '../tests/mock-drivers/MockDataStore';
-import { FileManager } from '../shared/interfaces/interfaces';
-import { MockS3Driver } from '../tests/mock-drivers/MockS3Driver';
 
-const dataStore: DataStore = new MockDataStore(); // DataStore
-const fileManager: FileManager = new MockS3Driver();
-
-describe('submitForReview', () => {
-  it('should submit given a valid username and id', async () => {
-    try {
-      expect(
-        await submitForReview({
-          dataStore,
-          fileManager,
-          user: MOCK_OBJECTS.USERTOKEN,
-          learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
-          userId: MOCK_OBJECTS.USER_ID,
-          collection: SUBMITTABLE_LEARNING_OBJECT.collection,
-        }),
-      ).resolves.toBe(undefined);
-    } catch (error) {
-      console.log(error);
-    }
-  });
-  describe('Learning Object validation errors', () => {
-    it('should return an error when a learning object without a name is provided', async done => {
-      expect.assertions(1);
-      try {
-        await submitForReview({
-          dataStore,
-          fileManager,
-          user: MOCK_OBJECTS.USERTOKEN,
-          learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
-          userId: MOCK_OBJECTS.USER_ID,
-          collection: SUBMITTABLE_LEARNING_OBJECT.collection,
-        });
-      } catch (e) {
-        expect(e instanceof Error).toBeTruthy();
-        done();
-      }
-    });
-    it('should return an error when a learning object without outcomes is provided', async done => {
-      expect.assertions(1);
-      try {
-        await submitForReview({
-          dataStore,
-          fileManager,
-          user: MOCK_OBJECTS.USERTOKEN,
-          learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
-          userId: MOCK_OBJECTS.USER_ID,
-          collection: SUBMITTABLE_LEARNING_OBJECT.collection,
-        });
-      } catch (e) {
-        expect(e instanceof Error).toBeTruthy();
-        done();
-      }
-    });
-    it('should return an error when a learning object without a description is provided', async done => {
-      expect.assertions(1);
-      try {
-        await submitForReview({
-          dataStore,
-          fileManager,
-          user: MOCK_OBJECTS.USERTOKEN,
-          learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
-          userId: MOCK_OBJECTS.USER_ID,
-          collection: SUBMITTABLE_LEARNING_OBJECT.collection,
-        });
-      } catch (e) {
-        expect(e instanceof Error).toBeTruthy();
-        done();
-      }
-    });
-  });
-});
+const dataStore: DataStore = new MockDataStore();
 
 describe('cancelSubmission', () => {
   it('should cancel the submission given a valid username and id', async done => {
-    try {
-      await expect(
-        cancelSubmission({
-          dataStore,
-          userId: MOCK_OBJECTS.USER_ID,
-          emailVerified: true,
-          learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
-        }),
-      ).resolves.toBe(undefined);
-      done();
-    } catch (error) {
-      console.log(error);
-    }
+    await expect(
+      cancelSubmission({
+        dataStore,
+        userId: MOCK_OBJECTS.USER_ID,
+        emailVerified: true,
+        learningObjectId: SUBMITTABLE_LEARNING_OBJECT.id,
+      }),
+    ).resolves.toBe(undefined);
+    done();
   });
 });
 


### PR DESCRIPTION
This PR removes tests that are wrongfully passing due to bad logic in the tests or poorly configured test environment conditions.

After talking with @nvisal1, we also realized that these tests are make assertions about the helper functions they use, not the logic they implement, and therefore should be rewritten. This PR only removes the bad tests, and future work with our test environment will go back to implement new, better tests.