### PR TITLE
Handle `guidelines` and `standardOutcomeIDs` filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1",
+  "version": "2.21.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1",
+  "version": "2.21.1-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSearch/Interactor.ts
+++ b/src/LearningObjectSearch/Interactor.ts
@@ -104,6 +104,7 @@ function formatSearchQuery(
   formattedQuery.standardOutcomeIDs = toArray(
     formattedQuery.standardOutcomeIDs,
   );
+  formattedQuery.guidelines = toArray(formattedQuery.guidelines);
   formattedQuery.page = toNumber(formattedQuery.page);
   formattedQuery.limit = toNumber(formattedQuery.limit);
   formattedQuery.sortType = <1 | -1>toNumber(formattedQuery.sortType);

--- a/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
+++ b/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
@@ -183,6 +183,7 @@ export class ElasticSearchLearningObjectDatastore
 
   /**
    * Returns all defined query filters
+   * Some filters are re-mapped to adhere to the documents structure within the index
    *
    * @private
    * @param {LearningObjectSearchQuery} params [Object containing search text, and field queries]
@@ -206,8 +207,8 @@ export class ElasticSearchLearningObjectDatastore
         level,
         collection,
         status,
-        standardOutcomeIDs,
-        guidelines,
+        'outcomes.mappings.id': standardOutcomeIDs,
+        'outcomes.mappings.source': guidelines,
       },
     });
     return queryFilters || {};
@@ -384,7 +385,6 @@ export class ElasticSearchLearningObjectDatastore
 
   /**
    * Constructs array of terms filter objects from filters
-   * Some properties are re-mapped to match the document storage structure
    *
    * @private
    * @param {Partial<LearningObjectSearchQuery>} filters [Object containing filters to be applied to set]
@@ -395,14 +395,6 @@ export class ElasticSearchLearningObjectDatastore
     filters: Partial<LearningObjectSearchQuery>,
   ): TermsQuery[] {
     const termsQueries: TermsQuery[] = [];
-    if (filters.standardOutcomeIDs) {
-      filters['outcomes.mappings.id'] = filters.standardOutcomeIDs;
-      delete filters.standardOutcomeIDs;
-    }
-    if (filters.guidelines) {
-      filters['outcomes.mappings.source'] = filters.guidelines;
-      delete filters.guidelines;
-    }
     Object.keys(filters).forEach(objectKey => {
       const termBody: { [property: string]: string[] } = {};
       termBody[`${objectKey}`] = filters[objectKey];

--- a/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
+++ b/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
@@ -192,13 +192,22 @@ export class ElasticSearchLearningObjectDatastore
   private getQueryFilters(
     params: LearningObjectSearchQuery,
   ): Partial<LearningObjectSearchQuery> {
-    const { length, level, collection, status } = params;
+    const {
+      length,
+      level,
+      collection,
+      status,
+      standardOutcomeIDs,
+      guidelines,
+    } = params;
     const queryFilters = sanitizeObject({
       object: {
         length,
         level,
         collection,
         status,
+        standardOutcomeIDs,
+        guidelines,
       },
     });
     return queryFilters || {};
@@ -375,6 +384,7 @@ export class ElasticSearchLearningObjectDatastore
 
   /**
    * Constructs array of terms filter objects from filters
+   * Some properties are re-mapped to match the document storage structure
    *
    * @private
    * @param {Partial<LearningObjectSearchQuery>} filters [Object containing filters to be applied to set]
@@ -385,6 +395,14 @@ export class ElasticSearchLearningObjectDatastore
     filters: Partial<LearningObjectSearchQuery>,
   ): TermsQuery[] {
     const termsQueries: TermsQuery[] = [];
+    if (filters.standardOutcomeIDs) {
+      filters['outcomes.mappings.id'] = filters.standardOutcomeIDs;
+      delete filters.standardOutcomeIDs;
+    }
+    if (filters.guidelines) {
+      filters['outcomes.mappings.source'] = filters.guidelines;
+      delete filters.guidelines;
+    }
     Object.keys(filters).forEach(objectKey => {
       const termBody: { [property: string]: string[] } = {};
       termBody[`${objectKey}`] = filters[objectKey];

--- a/src/LearningObjectSearch/typings/query.ts
+++ b/src/LearningObjectSearch/typings/query.ts
@@ -17,6 +17,7 @@ export interface ReleasedLearningObjectSearchQuery extends Filters {
   standardOutcomeIDs?: string[];
   text?: string;
   collection?: string[];
+  guidelines?: string[];
 }
 
 export interface LearningObjectSearchQuery


### PR DESCRIPTION
**Purpose of this PR**
Fixes issue where `guidelines` and `standardOutcomeIDs` filters were not being applied to the query within`ElasticSearchLearningObjectDatastore`. 

**Approach**
These filters are re-mapped within the `getQueryFilters` function to match the structure of the documents within the ElasticSearch index.