### PR TITLE
Update search response payload to `LearningObjectSummary`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1-1",
+  "version": "2.21.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1-1",
+  "version": "2.21.1-2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
+++ b/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
@@ -8,6 +8,10 @@ import {
   BoolOperation,
   SortOperation,
   TermsQuery,
+  LearningObjectSummary,
+  AuthorSummary,
+  LearningObject,
+  User,
 } from '../../typings';
 import { SearchResponse } from 'elasticsearch';
 import { LearningObject } from '../../../shared/entity';
@@ -440,11 +444,50 @@ export class ElasticSearchLearningObjectDatastore
   ): LearningObjectSearchResult {
     const total = results.hits.total;
     const hits = results.hits.hits;
-    const objects: LearningObject[] = [];
-    hits.forEach(set => {
-      objects.push(set._source as LearningObject);
-    });
+    const objects: LearningObjectSummary[] = hits.map(doc =>
+      this.mapLearningObjectToSummary(doc._source),
+    );
     return { total, objects };
+  }
+
+  /**
+   * Converts partial ElasticSearch LearningObject type into LearningObjectSummary
+   *
+   * @private
+   * @param {Partial<LearningObject>} object [The document data to convert to AuthorSummary]
+   * @returns {LearningObjectSummary}
+   * @memberof ElasticSearchLearningObjectDatastore
+   */
+  private mapLearningObjectToSummary(
+    object: Partial<LearningObject>,
+  ): LearningObjectSummary {
+    return {
+      id: object.id,
+      author: this.mapAuthorToSummary(object.author),
+      collection: object.collection,
+      contributors: object.contributors.map(this.mapAuthorToSummary),
+      date: object.date,
+      description: object.description,
+      length: object.length,
+      name: object.name,
+      status: object.status,
+    };
+  }
+
+  /**
+   * Converts Partial ElasticSearch User type into AuthorSummary
+   *
+   * @private
+   * @param {Partial<User>} author [The document data to convert to AuthorSummary]
+   * @returns {AuthorSummary}
+   * @memberof ElasticSearchLearningObjectDatastore
+   */
+  private mapAuthorToSummary(author: Partial<User>): AuthorSummary {
+    return {
+      id: author.id,
+      name: author.name,
+      organization: author.organization,
+    };
   }
 
   /**

--- a/src/LearningObjectSearch/typings/index.ts
+++ b/src/LearningObjectSearch/typings/index.ts
@@ -1,4 +1,4 @@
-import { LearningObject } from '../../shared/entity';
+import { LearningObject, User } from '../../shared/entity';
 import { UserToken as Requester } from '../../shared/types/user-token';
 import {
   ElasticSearchQuery,
@@ -20,6 +20,7 @@ import {
 
 export {
   LearningObject,
+  User,
   Requester,
   ElasticSearchQuery,
   SortOperation,
@@ -36,7 +37,25 @@ export {
   CollectionAccessMap,
 };
 
+export interface AuthorSummary {
+  id: string;
+  name: string;
+  organization: string;
+}
+
+export interface LearningObjectSummary {
+  id: string;
+  author: AuthorSummary;
+  collection: string;
+  contributors: AuthorSummary[];
+  date: string;
+  description: string;
+  length: string;
+  name: string;
+  status: string;
+}
+
 export interface LearningObjectSearchResult {
   total: number;
-  objects: LearningObject[];
+  objects: LearningObjectSummary[];
 }


### PR DESCRIPTION
**Purpose of this PR**
Defines and enforces `LearningObjectSummary` contract for search request on Learning Objects. This type includes the minimal set of properties needed to provide clients information about a Learning Object, and to fetch more information about a Learning Object. 