### PR TITLE
Perform prefix phrase match on outcome text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1-2",
+  "version": "2.21.1-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.21.1-2",
+  "version": "2.21.1-3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
+++ b/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
@@ -14,7 +14,6 @@ import {
   User,
 } from '../../typings';
 import { SearchResponse } from 'elasticsearch';
-import { LearningObject } from '../../../shared/entity';
 import * as request from 'request-promise';
 import { LearningObjectDatastore } from '../../interfaces';
 import { sanitizeObject } from '../../../shared/functions';
@@ -28,15 +27,12 @@ import {
 
 const SEARCHABLE_FIELDS = [
   'name',
-  'levels',
   'collection.keyword',
   'description',
   'author.name',
   'author.email',
   'author.organization',
   'outcomes.text',
-  'outcomes.bloom',
-  'outcomes.outcome',
 ];
 
 const ELASTICSEARCH_DOMAIN = process.env.ELASTICSEARCH_DOMAIN;
@@ -51,6 +47,8 @@ const QUERY_DEFAULTS = {
   ANALYZER: 'stop',
   MATCH_PHRASE_PREFIX_SLOP: 50,
   MATCH_PHRASE_PREFIX_EXPANSIONS: 50,
+  MATCH_OUTCOME_PHRASE_SLOP: 5,
+  MATCH_OUTCOME_EXPANSIONS: 5,
 };
 
 export class ElasticSearchLearningObjectDatastore
@@ -156,6 +154,15 @@ export class ElasticSearchLearningObjectDatastore
                   query: text,
                   max_expansions: QUERY_DEFAULTS.MATCH_PHRASE_PREFIX_EXPANSIONS,
                   slop: QUERY_DEFAULTS.MATCH_PHRASE_PREFIX_SLOP,
+                },
+              },
+            },
+            {
+              match_phrase_prefix: {
+                'outcomes.text': {
+                  query: text,
+                  max_expansions: QUERY_DEFAULTS.MATCH_OUTCOME_EXPANSIONS,
+                  slop: QUERY_DEFAULTS.MATCH_OUTCOME_PHRASE_SLOP,
                 },
               },
             },

--- a/src/LearningObjectSearch/typings/elastic-search.ts
+++ b/src/LearningObjectSearch/typings/elastic-search.ts
@@ -36,7 +36,7 @@ export interface MultiMatchQuery {
 
 export interface MatchPhrasePrefixQuery {
   match_phrase_prefix: {
-    description: {
+    [x: string]: {
       query: string;
       max_expansions: number;
       slop: number;


### PR DESCRIPTION
**Purpose of this PR**
Extends search capabilities by added prefix phrase match stage on `outcomes.text` field.

Co-authored-by: David Nsoesie <davidnsoesie1@gmail.com>