### PR TITLE
Tag Learning Objects with revision 0 when created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.22.0-3",
+  "version": "2.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.22.0-3",
+  "version": "2.23.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -312,6 +312,7 @@ export async function addLearningObject(
       ...object.toPlainObject(),
       author,
     });
+    objectInsert.revision = 0;
     const learningObjectID = await dataStore.insertLearningObject(objectInsert);
     objectInsert.id = learningObjectID;
     return objectInsert;

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -2281,6 +2281,7 @@ export class MongoDriver implements DataStore {
       outcomes,
       hasRevision: record.hasRevision,
       children,
+      revision: record.revision,
     });
 
     return learningObject;

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -2217,6 +2217,7 @@ export class MongoDriver implements DataStore {
         collection: object.collection,
         status: object.status,
         children: object.children.map(obj => obj.id),
+        revision: object.revision,
       };
 
       return doc;

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -408,6 +408,18 @@ export class LearningObject {
     return this._hasRevision;
   }
 
+  private _revision!: number;
+  /**
+   * @property {string} revision The version number of the Learning Object
+   *
+   */
+  get revision(): number {
+    return this._revision;
+  }
+  set revision(revision: number) {
+    this._revision = revision;
+  }
+
   /**
    * Map deprecated status values to new LearningObject.Status values
    *
@@ -477,6 +489,7 @@ export class LearningObject {
     this._collection = '';
     this._status = LearningObject.Status.UNRELEASED;
     this._metrics = { saves: 0, downloads: 0 };
+    this._revision = 0;
     if (object) {
       this.copyObject(object);
     }
@@ -530,6 +543,9 @@ export class LearningObject {
     }
     if (object.hasRevision === true) {
       this._hasRevision = object.hasRevision;
+    }
+    if (object.revision != null) {
+      this.revision = object.revision;
     }
     this.collection = <string>object.collection || this.collection;
     this.status = <LearningObject.Status>object.status || this.status;

--- a/src/shared/types/learning-object-document.ts
+++ b/src/shared/types/learning-object-document.ts
@@ -15,6 +15,7 @@ export interface LearningObjectDocument {
   collection: string;
   status: string;
   hasRevision?: boolean;
+  revision: number;
 }
 
 export interface MaterialDocument {


### PR DESCRIPTION
This PR adds the `revision` property to Learning Objects and tags Learning Objects with a revision number of `0` when they are first created.