### PR TITLE
Move LearningObjectSummary types to shared

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1",
+  "version": "2.23.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1",
+  "version": "2.23.1-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSearch/typings/index.ts
+++ b/src/LearningObjectSearch/typings/index.ts
@@ -17,6 +17,7 @@ import {
   PrivilegedLearningObjectSearchQuery,
   CollectionAccessMap,
 } from './query';
+import { LearningObjectSummary, AuthorSummary } from '../../shared/types';
 
 export {
   LearningObject,
@@ -35,25 +36,9 @@ export {
   ReleasedLearningObjectSearchQuery,
   PrivilegedLearningObjectSearchQuery,
   CollectionAccessMap,
+  LearningObjectSummary,
+  AuthorSummary,
 };
-
-export interface AuthorSummary {
-  id: string;
-  name: string;
-  organization: string;
-}
-
-export interface LearningObjectSummary {
-  id: string;
-  author: AuthorSummary;
-  collection: string;
-  contributors: AuthorSummary[];
-  date: string;
-  description: string;
-  length: string;
-  name: string;
-  status: string;
-}
 
 export interface LearningObjectSearchResult {
   total: number;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -13,6 +13,10 @@ import { UserDocument } from './user-document';
 import { LearningOutcomeDocument } from './learning-outcome-document';
 import { StandardOutcomeDocument } from './standard-outcome-document';
 import { ServiceToken } from './service-token';
+import {
+  LearningObjectSummary,
+  AuthorSummary,
+} from './learning-object-summary';
 
 export {
   UserToken,
@@ -26,4 +30,6 @@ export {
   UrlDocument,
   LearningOutcomeDocument,
   StandardOutcomeDocument,
+  LearningObjectSummary,
+  AuthorSummary,
 };

--- a/src/shared/types/learning-object-summary.ts
+++ b/src/shared/types/learning-object-summary.ts
@@ -1,19 +1,74 @@
+/**
+ * An interface representation of the AuthorSummary type
+ *
+ * @export
+ * @interface AuthorSummary
+ */
 export interface AuthorSummary {
+  /**
+   * Unique identifier of the author/user
+   */
   id: string;
+  /**
+   * Human readable unique identifier of the author/user
+   */
   username: string;
+  /**
+   * The full name of the author/user
+   */
   name: string;
+  /**
+   * The organization of the author/user
+   */
   organization: string;
 }
 
+/**
+ * An interface representation of the LearningObjectSummary type
+ *
+ * @export
+ * @interface LearningObjectSummary
+ */
 export interface LearningObjectSummary {
+  /**
+   * Unique identifier of the Learning Object
+   */
   id: string;
+  /**
+   * Summary information of the user who authored the Learning Object
+   */
   author: AuthorSummary;
+  /**
+   * The collection the Learning Object was submitted to
+   */
   collection: string;
+  /**
+   * Summary information about users who have made contributions to the Learning Object
+   */
   contributors: AuthorSummary[];
+  /**
+   * Time at which the Learning Object was last updated
+   * Value is a string representing the milliseconds elapsed since the UNIX epoch
+   */
   date: string;
+  /**
+   * User supplied information about the contents/purpose of the Learning Object
+   */
   description: string;
+  /**
+   * How long the content of the Learning Object
+   */
   length: string;
+  /**
+   * The name of the Learning Object
+   */
   name: string;
+  /**
+   * The version number of the Learning Object
+   */
   revision: number;
+  /**
+   * The stage within the review pipeline that the Learning Object exists
+   */
   status: string;
 }

--- a/src/shared/types/learning-object-summary.ts
+++ b/src/shared/types/learning-object-summary.ts
@@ -1,0 +1,19 @@
+export interface AuthorSummary {
+  id: string;
+  username: string;
+  name: string;
+  organization: string;
+}
+
+export interface LearningObjectSummary {
+  id: string;
+  author: AuthorSummary;
+  collection: string;
+  contributors: AuthorSummary[];
+  date: string;
+  description: string;
+  length: string;
+  name: string;
+  revision: number;
+  status: string;
+}


### PR DESCRIPTION
This PR moves `LearningObjectSummary` types to shared.