### PR TITLE
Fix search results only returning objects in collection for privileged users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1-8",
+  "version": "2.23.1-9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1-8",
+  "version": "2.23.1-9",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
+++ b/src/LearningObjectSearch/drivers/LearningObjectDatastore/ElasticSearchLearningObjectDatastore.ts
@@ -469,7 +469,7 @@ export class ElasticSearchLearningObjectDatastore
     }
     let aggFilters: any = {
       bool: {
-        must: [
+        should: [
           {
             bool: {
               must: this.convertQueryFiltersToTerms(queryFilters),
@@ -480,10 +480,11 @@ export class ElasticSearchLearningObjectDatastore
     };
 
     if (restrictions && Object.keys(restrictions).length) {
-      aggFilters = this.buildCollectionRestrictionFilter({
+      const restrictionFilter = this.buildCollectionRestrictionFilter({
         filters: queryFilters,
         restrictions,
       });
+      aggFilters.bool.should.push(restrictionFilter);
     }
 
     query.aggs = {


### PR DESCRIPTION
This PR fixes ElasticSearch results only returning objects in collection for privileged users.