### PR TITLE
Expose uploadFile function through FileManager Adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1-11",
+  "version": "2.24.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "2.23.1-11",
+  "version": "2.24.0-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/FileInteractor.ts
+++ b/src/FileManager/FileInteractor.ts
@@ -148,6 +148,23 @@ export async function abortMultipartUpload(params: {
 }
 
 /**
+ * Instructs file manager to upload a single file
+ *
+ * @export
+ * @param {{ FileManager }} fileManager
+ * @param {{ FileUpload }} file
+ * @returns {string}
+ */
+export async function uploadFile(params: {
+  fileManager: FileManager,
+  file: FileUpload,
+}): Promise<void> {
+  await params.fileManager.upload({
+    file: params.file,
+  });
+}
+
+/**
  * Gets file type
  *
  * @export

--- a/src/FileManager/FileManagerAdapter.ts
+++ b/src/FileManager/FileManagerAdapter.ts
@@ -1,0 +1,39 @@
+import { FileManager } from '../shared/interfaces/interfaces';
+import { uploadFile } from './FileInteractor';
+import { FileUpload } from '../shared/interfaces/FileManager';
+export class FileManagerAdapter {
+    private static _instance: FileManagerAdapter;
+    private constructor(
+        private fileManager: FileManager,
+    ) {}
+    static open(fileManager: FileManager): void {
+        FileManagerAdapter._instance = new FileManagerAdapter(
+            fileManager,
+        );
+    }
+
+    static getInstance(): FileManagerAdapter {
+        if (this._instance) {
+            return this._instance;
+        }
+        throw new Error('FileManagerAdapter has not been created yet.');
+    }
+
+    /**
+     * Instructs file manager to upload a single file
+     *
+     * @export
+     * @param {{ FileManager }} fileManager
+     * @param {{ FileUpload }} file
+     * @returns {string}
+     */
+    async uploadfile(params: {
+        fileManager: FileManager,
+        file: FileUpload,
+    }) {
+        return await uploadFile({
+            fileManager: params.fileManager,
+            file: params.file,
+        });
+    }
+}

--- a/src/FileManager/FileManagerAdapter.ts
+++ b/src/FileManager/FileManagerAdapter.ts
@@ -20,19 +20,18 @@ export class FileManagerAdapter {
     }
 
     /**
-     * Instructs file manager to upload a single file
+     * Proxies request to FileInteractor uploadFile function
      *
      * @export
      * @param {{ FileManager }} fileManager
      * @param {{ FileUpload }} file
      * @returns {string}
      */
-    async uploadfile(params: {
-        fileManager: FileManager,
+    async uploadFile(params: {
         file: FileUpload,
     }) {
         return await uploadFile({
-            fileManager: params.fileManager,
+            fileManager: this.fileManager,
             file: params.file,
         });
     }

--- a/src/FileMetadata/interfaces/FileManagerGateway.ts
+++ b/src/FileMetadata/interfaces/FileManagerGateway.ts
@@ -1,0 +1,15 @@
+import { FileUpload } from '../../shared/interfaces/FileManager';
+
+export abstract class FileManagerGateway {
+
+  /**
+   * Upload a single file
+   *
+   * @param {fileUpload} file [Object containing information about the file to upload ]
+   * @memberof FileManagerGateway
+   * @returns {Promise<void>}
+   */
+    abstract uploadFile(params: {
+        file: FileUpload,
+    }): Promise<void>;
+}

--- a/src/LearningObjects/Publishing/ModuleFileManagerGateway.ts
+++ b/src/LearningObjects/Publishing/ModuleFileManagerGateway.ts
@@ -1,0 +1,22 @@
+import { FileManagerAdapter } from '../../FileManager/FileManagerAdapter';
+import { FileUpload } from '../../shared/interfaces/FileManager';
+import { FileManagerGateway } from '../../FileMetadata/interfaces/FileManagerGateway';
+
+export class ModuleFileManagerGateway extends FileManagerGateway {
+    private adapter: FileManagerAdapter = FileManagerAdapter.getInstance();
+
+  /**
+   * @inheritdoc
+   *
+   * Proxies `uploadFile` request to FileManagerAdapter
+   *
+   * @memberof ModuleFileManagerGateway
+   */
+    uploadFile(params: {
+        file: FileUpload,
+    }) {
+        return this.adapter.uploadFile({
+            file: params.file,
+        });
+    }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import { MongoConnector } from './shared/Mongo/MongoConnector';
 import { LearningObjectAdapter } from './LearningObjects/LearningObjectAdapter';
 import { LearningObjectSearch } from './LearningObjectSearch';
 import { HierarchyAdapter } from './LearningObjects/Hierarchy/HierarchyAdapter';
+import { FileManagerAdapter } from './FileManager/FileManagerAdapter';
 
 // ----------------------------------------------------------------------------------
 // Initializations
@@ -82,6 +83,7 @@ function initModules() {
   HierarchyAdapter.open(dataStore);
   LearningObjectAdapter.open(dataStore, fileManager);
   LearningObjectSearch.initialize();
+  FileManagerAdapter.open(fileManager);
 }
 
 /**


### PR DESCRIPTION
***Purpose of this PR***
The Publishing module needs the ability to request that a file be uploaded to a Learning Object when it is released. This will allow us to upload the bundled files and the meta.json file.

***Changes***
 - Create a `FileModuleAdapter` that exposes `FileInteractor` functions. 
 - Create a 'ModuleFileModuleGateway` so the publishing module can access the `FileModuleAdapter`
 - Create a `FileModuleGateway` abstract class for the `ModuleFileModuleGateway`
 - Initialize the `FileModuleAdapter` singleton instance in `app.ts`
