### PR TITLE
Fix parent files being linked to child Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.2-1",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.3",
+  "version": "3.0.2-1",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.2-1",
+  "version": "3.0.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.0.3",
+  "version": "3.0.2-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -961,6 +961,12 @@ export async function getLearningObjectById({
         id: learningObject.id,
         full: false,
       });
+      children = await Promise.all(
+        children.map(async child => {
+          child.materials = await dataStore.fetchReleasedMaterials(child.id);
+          return child;
+        }),
+      );
     } else {
       const childrenStatus = requesterIsAuthor({
         requester,
@@ -1020,6 +1026,9 @@ async function loadChildObjectSummaries({
   });
   children = await Promise.all(
     children.map(async child => {
+      child.materials = await dataStore.getLearningObjectMaterials({
+        id: child.id,
+      });
       child.materials.files = await Gateways.fileMetadata().getAllFileMetadata({
         requester,
         learningObjectId: child.id,

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -961,6 +961,7 @@ export async function getLearningObjectById({
         id: learningObject.id,
         full: false,
       });
+      // FIXME: Children should be mapped to LearningObjectSummary type which doesn't include materials
       children = await Promise.all(
         children.map(async child => {
           child.materials = await dataStore.fetchReleasedMaterials(child.id);
@@ -1025,6 +1026,7 @@ async function loadChildObjectSummaries({
     status: childrenStatus,
   });
   children = await Promise.all(
+    // FIXME: Children should be mapped to LearningObjectSummary type which doesn't include materials or files
     children.map(async child => {
       child.materials = await dataStore.getLearningObjectMaterials({
         id: child.id,

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -1022,7 +1022,7 @@ async function loadChildObjectSummaries({
     children.map(async child => {
       child.materials.files = await Gateways.fileMetadata().getAllFileMetadata({
         requester,
-        learningObjectId: parentId,
+        learningObjectId: child.id,
         filter: 'unreleased',
       });
       return child;


### PR DESCRIPTION
**Purpose of this PR**
Fixes parent Learning Object files being set as the child Learning Objects' files. 

**Changes in this PR**
- Fix incorrect parameter being passed when fetching files for child Learning Objects
- Temporarily add materials to children

Materials are added to children temporarily because right now the service responds with the `children` property being "summaries" which don't have defined values for`materials`. This breaks the downloads for Learning Objects with children, because the children don't have `materials.pdf` defined causing errors when trying to fetch their READMEs.

This is a temporary fix as we work to have library service fetch full child objects individually.