### PR TITLE
Convert forEach to for of to allow error to propagate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileMetadata/Interactor.ts
+++ b/src/FileMetadata/Interactor.ts
@@ -295,7 +295,7 @@ function generateFileMetadataInserts(
   learningObject: LearningObjectSummary,
 ) {
   const inserts: FileMetadataInsert[] = [];
-  files.forEach(async file => {
+  for (const file of files) {
     const cleanFile = sanitizeObject({ object: file }, false);
     validateFileMeta(cleanFile);
     const newInsert: FileMetadataInsert = generateFileMetaInsert(
@@ -303,7 +303,7 @@ function generateFileMetadataInserts(
       learningObject,
     );
     inserts.push(newInsert);
-  });
+  }
   return inserts;
 }
 


### PR DESCRIPTION
**Purpose of this PR**
Fixes error propagation when validating file metadata.

**Changes**
- Convert `forEach` loop to `for of` loop to allow error to bubble up.