### PR TITLE
Get fully qualified children Learning Objects when releasing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSubmission/interactors/submitForReview.ts
+++ b/src/LearningObjectSubmission/interactors/submitForReview.ts
@@ -87,7 +87,9 @@ function verifyIsSubmittable(params: { user: UserToken; userId: string; }, objec
   }
   try {
     // tslint:disable-next-line:no-unused-expression
-    new SubmittableLearningObject(object);
+    new SubmittableLearningObject(
+      new LearningObject({ ...object.toPlainObject(), children: [] }),
+    );
   } catch (error) {
     if (error instanceof EntityError) {
       throw new ResourceError(error.message, ResourceErrorReason.BAD_REQUEST);

--- a/src/shared/interfaces/DataStore.ts
+++ b/src/shared/interfaces/DataStore.ts
@@ -174,6 +174,19 @@ export interface DataStore
     full?: boolean;
     status: string[];
   }): Promise<LearningObject[]>;
+
+  /**
+   * Loads released child Learning Objects for a working parent Learning Object
+   *
+   * @param {string} id [The id of the working parent Learning Object]
+   * @param {boolean} full [Whether or not to load the full children Learning Objects]
+   *
+   * @returns {Promise<LearningObject[]>}
+   */
+  loadWorkingParentsReleasedChildObjects(params: {
+    id: string;
+    full?: boolean;
+  }): Promise<LearningObject[]>;
   loadReleasedChildObjects(params: {
     id: string;
     full?: boolean;

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -120,7 +120,7 @@ export class MockDataStore implements DataStore, SubmissionDataStore {
     id: string;
     full?: boolean;
   }): Promise<LearningObject[]> {
-    return Promise.resolve([this.stubs.learningObjectChild as any]);
+    return Promise.resolve([]);
   }
 
   addToReleased(object: LearningObject): Promise<void> {

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -120,6 +120,9 @@ export class MockDataStore implements DataStore, SubmissionDataStore {
     id: string;
     full?: boolean;
   }): Promise<LearningObject[]> {
+    if (params.id !== this.stubs.learningObjectChild.id) {
+      return Promise.resolve([this.stubs.learningObjectChild]);
+    }
     return Promise.resolve([]);
   }
 

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -38,6 +38,16 @@ export class MockDataStore implements DataStore, SubmissionDataStore {
     return;
   }
 
+  loadWorkingParentsReleasedChildObjects(params: {
+    id: string;
+    full?: boolean;
+  }): Promise<LearningObject[]> {
+    if (params.id !== this.stubs.learningObjectChild.id) {
+      return Promise.resolve([this.stubs.learningObjectChild]);
+    }
+    return Promise.resolve([]);
+  }
+
   searchReleasedUserObjects(
     query: ReleasedUserLearningObjectSearchQuery,
     username: string,


### PR DESCRIPTION
**Purpose of this PR**
Fix issues with releasing Learning Objects with children Learning Objects.

**Changes in this PR**
- Create `loadWorkingParentsReleasedChildObjects` function to recursively load the fully qualified released child Learning Objects of a working Learning Object.
This populates the child Learning Objects with all the data needed for the Learning Objects to be bundled and released including all material metadata.
- Update `verifySubmittable` to only validate top level Learning Object that is being submitted is submittable.