### PR TITLE
Fix search by guidelines for non-privileged users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -38,11 +38,7 @@ import {
   ServiceErrorReason,
 } from '../shared/errors';
 import { reportError } from '../shared/SentryConnector';
-import {
-  LearningObject,
-  LearningOutcome,
-  User,
-} from '../shared/entity';
+import { LearningObject, LearningOutcome, User } from '../shared/entity';
 import { MongoConnector } from '../shared/Mongo/MongoConnector';
 import { mapLearningObjectToSummary } from '../shared/functions';
 import {
@@ -451,10 +447,12 @@ export class MongoDriver implements DataStore {
     // Query for users
     const authors = await this.matchUsers(author, text);
     // Query by LearningOutcomes' mappings
-    const outcomeIDs: string[] = await this.matchOutcomesByGuidelines({
-      guidelineIds: standardOutcomeIDs,
-      guidelineSources: guidelines,
-    });
+    const learningObjectIds: string[] = await this.matchLearningObjectsByGuidelines(
+      {
+        guidelineIds: standardOutcomeIDs,
+        guidelineSources: guidelines,
+      },
+    );
 
     const searchQuery = this.buildSearchQuery({
       name,
@@ -463,7 +461,7 @@ export class MongoDriver implements DataStore {
       length,
       level,
       text,
-      outcomeIDs,
+      learningObjectIds,
       status,
     });
 
@@ -1822,20 +1820,23 @@ export class MongoDriver implements DataStore {
       const authors = await this.matchUsers(author, text);
 
       // Query by LearningOutcomes' mappings
-      const outcomeIDs: string[] = await this.matchOutcomesByGuidelines({
-        guidelineIds: standardOutcomeIDs,
-        guidelineSources: guidelines,
-      });
+      const learningObjectIds: string[] = await this.matchLearningObjectsByGuidelines(
+        {
+          guidelineIds: standardOutcomeIDs,
+          guidelineSources: guidelines,
+        },
+      );
 
       let query: any = this.buildSearchQuery({
         text,
         authors,
         length,
         level,
-        outcomeIDs,
+        learningObjectIds,
         name,
         collection,
       });
+      console.log('TCL: query', JSON.stringify(query));
 
       let objectCursor = await this.db
         .collection(COLLECTIONS.RELEASED_LEARNING_OBJECTS)
@@ -1875,8 +1876,7 @@ export class MongoDriver implements DataStore {
    * @param {string[]} authorIDs
    * @param {string[]} length
    * @param {string[]} level
-   * @param {string[]} guidelines
-   * @param {string[]} outcomeIDs
+   * @param {string[]} learningObjectIds
    * @param {string} name
    * @returns
    * @memberof MongoDriver
@@ -1887,8 +1887,7 @@ export class MongoDriver implements DataStore {
     status?: string[];
     length?: string[];
     level?: string[];
-    guidelines?: string[];
-    outcomeIDs?: string[];
+    learningObjectIds?: string[];
     name?: string;
     collection?: string[];
   }) {
@@ -1923,32 +1922,34 @@ export class MongoDriver implements DataStore {
    * @returns
    * @memberof MongoDriver
    */
-  private buildFieldSearchQuery(params: {
+  private buildFieldSearchQuery({
+    query,
+    name,
+    authors,
+    status,
+    length,
+    level,
+    learningObjectIds,
+    collection,
+  }: {
     query: any;
     name?: string;
     authors?: { _id: string; username: string }[];
     status?: string[];
     length?: string[];
     level?: string[];
-    guidelines?: string[];
-    outcomeIDs?: string[];
+    learningObjectIds?: string[];
     collection?: string[];
   }) {
-    const {
-      query,
-      name,
-      authors,
-      status,
-      length,
-      level,
-      guidelines,
-      outcomeIDs,
-      collection,
-    } = params;
     if (name) {
       query.$text = { $search: name };
     }
+    if (Array.isArray(learningObjectIds)) {
+      query.$or = query.$or || [];
+      query.$or.push({ _id: { $in: learningObjectIds } });
+    }
     if (authors) {
+      query.$or = query.$or || [];
       query.$or.push(
         <any>{
           authorID: { $in: authors.map(author => author._id) },
@@ -1968,9 +1969,6 @@ export class MongoDriver implements DataStore {
     if (status) {
       query.status = { $in: status };
     }
-    if (outcomeIDs) {
-      query.outcomes = { $in: outcomeIDs };
-    }
     if (collection) {
       query.collection = { $in: collection };
     }
@@ -1987,36 +1985,38 @@ export class MongoDriver implements DataStore {
    * @param {{ _id: string; username: string }[]} authors
    * @param {string[]} length
    * @param {string[]} level
-   * @param {string[]} outcomeIDs
+   * @param {string[]} learningObjectIds
    * @returns
    * @memberof MongoDriver
    */
-  private buildTextSearchQuery(params: {
+  private buildTextSearchQuery({
+    query,
+    text,
+    authors,
+    status,
+    length,
+    level,
+    learningObjectIds,
+    collection,
+  }: {
     query: any;
     text: string;
     authors?: { _id: string; username: string }[];
     status?: string[];
     length?: string[];
     level?: string[];
-    outcomeIDs?: string[];
+    learningObjectIds?: string[];
     collection?: string[];
   }) {
-    const {
-      query,
-      text,
-      authors,
-      status,
-      length,
-      level,
-      outcomeIDs,
-      collection,
-    } = params;
     const regex = new RegExp(sanitizeRegex(text));
     query.$or = [
       { $text: { $search: text } },
       { name: { $regex: regex } },
       { contributors: { $regex: regex } },
     ];
+    if (Array.isArray(learningObjectIds)) {
+      query.$or.push({ _id: { $in: learningObjectIds } });
+    }
     if (authors && authors.length) {
       query.$or.push(
         <any>{
@@ -2038,11 +2038,6 @@ export class MongoDriver implements DataStore {
     }
     if (collection) {
       query.collection = { $in: collection };
-    }
-    if (outcomeIDs) {
-      query.outcomes = outcomeIDs.length
-        ? { $in: outcomeIDs }
-        : ['DONT MATCH ME'];
     }
     return query;
   }
@@ -2097,15 +2092,16 @@ export class MongoDriver implements DataStore {
   }
 
   /**
-   * Gets Learning Outcome IDs that are mapped to specific Guidelines
+   * Gets Learning Objects IDs that have outcomes mapped to specific guidelines
    * *** Note  to prevent matching when params are undefined, `null` is returned instead of an empty array ***
    *
    * @private
-   * @param {string[]} guidelineIds
-   * @returns {Promise<LearningOutcomeDocument[]>}
+   * @param {string[]} guidelineIds [Ids of the guidelines]
+   * @param {string[]} guidelineSources [Source names of the guidelines]
+   * @returns {Promise<string[]>}
    * @memberof MongoDriver
    */
-  private async matchOutcomesByGuidelines({
+  private async matchLearningObjectsByGuidelines({
     guidelineIds,
     guidelineSources,
   }: {
@@ -2113,7 +2109,7 @@ export class MongoDriver implements DataStore {
     guidelineSources?: string[];
   }): Promise<string[]> {
     if (guidelineSources) {
-      return this.matchOutcomesByGuidelineSource({
+      return this.matchLearningObjectsByGuidelineSource({
         guidelineIds,
         guidelineSources,
       });
@@ -2124,16 +2120,16 @@ export class MongoDriver implements DataStore {
           {
             mappings: { $all: guidelineIds },
           },
-          { projection: { _id: 1 } },
+          { projection: { _id: 0, source: 1 } },
         )
         .toArray();
-      return docs.map(doc => doc._id);
+      return docs.map(doc => doc.source);
     }
     return null;
   }
 
   /**
-   * Retrieves ids for Learning Outcomes that match specified source or specified source and mapping ids
+   * Retrieves ids for Learning Objects that have outcomes mapped to specified source or specified source and guideline ids
    *
    * @private
    * @param {string[]} guidelineIds [List of guideline/mappings ids to be matched]
@@ -2141,7 +2137,7 @@ export class MongoDriver implements DataStore {
    * @returns {Promise<string[]>}
    * @memberof MongoDriver
    */
-  private async matchOutcomesByGuidelineSource({
+  private async matchLearningObjectsByGuidelineSource({
     guidelineIds,
     guidelineSources,
   }: {
@@ -2165,7 +2161,7 @@ export class MongoDriver implements DataStore {
     }
     const results = await this.db
       .collection(COLLECTIONS.STANDARD_OUTCOMES)
-      .aggregate<{ outcomeIds: string[] }>([
+      .aggregate<{ learningObjectIds: string[] }>([
         { $match: { source: { $in: guidelineSources } } },
         {
           $lookup: {
@@ -2174,7 +2170,7 @@ export class MongoDriver implements DataStore {
             pipeline: [
               { $unwind: '$mappings' },
               learningOutcomeMatcher,
-              { $project: { _id: 1 } },
+              { $project: { _id: 0, source: 1 } },
             ],
             as: 'outcomes',
           },
@@ -2183,13 +2179,13 @@ export class MongoDriver implements DataStore {
         {
           $group: {
             _id: 1,
-            outcomeIds: { $addToSet: '$outcomes._id' },
+            learningObjectIds: { $addToSet: '$outcomes.source' },
           },
         },
       ])
       .toArray();
     if (results[0]) {
-      return results[0].outcomeIds;
+      return results[0].learningObjectIds;
     }
     return [];
   }

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -497,14 +497,13 @@ export class LearningObjectInteractor {
    * @returns {Promise<{ total: number; objects: LearningObject[] }>}
    * @memberof LearningObjectInteractor
    */
-  public static async searchObjects(params: {
+  public static async searchObjects({dataStore, library, query, userToken}: {
     dataStore: DataStore;
     library: LibraryCommunicator;
     query: LearningObjectQuery;
     userToken: UserToken;
   }): Promise<{ total: number; objects: LearningObject[] }> {
     try {
-      const { dataStore, library, query, userToken } = params;
       let {
         name,
         author,


### PR DESCRIPTION
**Purpose of this PR**
Fixes issue with searching by guidelines for non-privileged users

**Changes in this PR**
Updates search methods in `MongoDrirver` to match guidelines to outcomes to Learning Objects by id.
Update search on outcomes to search by id based on matched outcomes.