### PR TITLE
Generate previewUrls for files and return in response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileMetadata/FileMetadataModule.ts
+++ b/src/FileMetadata/FileMetadataModule.ts
@@ -12,12 +12,14 @@ import {
   deleteAllFileMetadata,
   getFileMetadata,
   getAllFileMetadata,
+  getFilePreviewUrl,
 } from './Interactor';
 import { ExpressHttpAdapter } from './adapters';
 import {
   ModuleLearningObjectGateway,
   ModuleFileManagerGateway,
 } from './gateways';
+import { LearningObjectFile } from './typings';
 
 /**
  * Module responsible for handling the management of file metadata
@@ -35,6 +37,24 @@ import {
   ],
 })
 export class FileMetadataModule extends ExpressServiceModule {
+  static getFilePreviewUrl = ({
+    authorUsername,
+    learningObjectId,
+    unreleased,
+    file,
+  }: {
+    authorUsername: string;
+    learningObjectId: string;
+    unreleased?: boolean;
+    file: LearningObjectFile;
+  }) =>
+    getFilePreviewUrl({
+      authorUsername,
+      learningObjectId,
+      unreleased,
+      fileId: file.id,
+      extension: file.extension,
+    })
   static getFileMetadata = getFileMetadata;
   static getAllFileMetadata = getAllFileMetadata;
   static deleteAllFileMetadata = deleteAllFileMetadata;

--- a/src/FileMetadata/Interactor.ts
+++ b/src/FileMetadata/Interactor.ts
@@ -1,5 +1,9 @@
 import { FileMetadataModule } from './FileMetadataModule';
-import { FileMetaDatastore, LearningObjectGateway, FileManagerGateway } from './interfaces';
+import {
+  FileMetaDatastore,
+  LearningObjectGateway,
+  FileManagerGateway,
+} from './interfaces';
 import {
   LearningObjectFile,
   Requester,
@@ -10,7 +14,11 @@ import {
   FileMetadataInsert,
   FileMetadataFilter,
 } from './typings';
-import { ResourceError, ResourceErrorReason, handleError } from '../shared/errors';
+import {
+  ResourceError,
+  ResourceErrorReason,
+  handleError,
+} from '../shared/errors';
 import {
   authorizeWriteAccess,
   authorizeReadAccess,
@@ -18,11 +26,15 @@ import {
 import { sanitizeObject, toNumber } from '../shared/functions';
 import { reportError } from '../shared/SentryConnector';
 import * as mime from 'mime-types';
+import { LearningObject } from '../shared/entity';
 
 const DEFAULT_MIME_TYPE = 'application/octet-stream';
+const MICROSOFT_PREVIEW_URL = process.env.MICROSOFT_PREVIEW_URL;
+const FILE_API_URI = process.env.LEARNING_OBJECT_API;
 
 namespace Drivers {
-  export const datastore = () => FileMetadataModule.resolveDependency(FileMetaDatastore);
+  export const datastore = () =>
+    FileMetadataModule.resolveDependency(FileMetaDatastore);
 }
 
 namespace Gateways {
@@ -83,18 +95,36 @@ export async function getFileMetadata({
 
       authorizeReadAccess({ learningObject, requester });
 
-      const file = await Drivers.datastore()
-        .fetchFileMeta(id);
+      const file = await Drivers.datastore().fetchFileMeta(id);
       if (!file) {
-        throw new ResourceError(`Unable to get file metadata for file ${id}. File does not exist.`, ResourceErrorReason.NOT_FOUND);
+        throw new ResourceError(
+          `Unable to get file metadata for file ${id}. File does not exist.`,
+          ResourceErrorReason.NOT_FOUND,
+        );
       }
-      return transformFileMetaToLearningObjectFile(file);
+      return transformFileMetaToLearningObjectFile({
+        authorUsername: learningObject.author.username,
+        learningObjectId: learningObject.author.id,
+        file,
+      });
     }
-
-    return Gateways.learningObjectGateway().getReleasedFile({
-      id: learningObjectId,
-      fileId: id,
-    });
+    const releasedObject: LearningObjectSummary = await Gateways.learningObjectGateway().getReleasedLearningObjectSummary(
+      learningObjectId,
+    );
+    return Gateways.learningObjectGateway()
+      .getReleasedFile({
+        id: learningObjectId,
+        fileId: id,
+      })
+      .then(file => {
+        file.previewUrl = getFilePreviewUrl({
+          authorUsername: releasedObject.author.username,
+          learningObjectId: releasedObject.id,
+          fileId: file.id,
+          extension: file.extension,
+        });
+        return file;
+      });
   } catch (e) {
     handleError(e);
   }
@@ -137,9 +167,12 @@ export async function getAllFileMetadata({
     });
     let releasedFiles$: Promise<LearningObjectFile[]>;
     if (!filter || filter === 'released') {
-      releasedFiles$ = Gateways.learningObjectGateway().getReleasedFiles(
+      const releasedObject: LearningObjectSummary = await Gateways.learningObjectGateway().getReleasedLearningObjectSummary(
         learningObjectId,
       );
+      releasedFiles$ = Gateways.learningObjectGateway()
+        .getReleasedFiles(learningObjectId)
+        .then(files => files.map(appendFilePreviewUrls(releasedObject)));
       if (filter === 'released') return releasedFiles$;
     }
     const learningObject: LearningObjectSummary = await Gateways.learningObjectGateway().getWorkingLearningObjectSummary(
@@ -155,7 +188,15 @@ export async function getAllFileMetadata({
 
     const workingFiles$ = Drivers.datastore()
       .fetchAllFileMeta(learningObjectId)
-      .then(files => files.map(transformFileMetaToLearningObjectFile));
+      .then(files =>
+        files.map(file =>
+          transformFileMetaToLearningObjectFile({
+            authorUsername: learningObject.author.username,
+            learningObjectId: learningObject.id,
+            file,
+          }),
+        ),
+      );
 
     if (filter === 'unreleased') return workingFiles$;
 
@@ -169,6 +210,35 @@ export async function getAllFileMetadata({
   } catch (e) {
     handleError(e);
   }
+}
+
+/**
+ * Appends file preview urls to files
+ *
+ * @param {LearningObjectSummary} learningObject
+ * @returns {(
+ *   value: LearningObjectFile,
+ *   index: number,
+ *   array: LearningObjectFile[],
+ * ) => LearningObjectFile}
+ */
+function appendFilePreviewUrls(
+  learningObject: LearningObjectSummary,
+): (
+  value: LearningObjectFile,
+  index: number,
+  array: LearningObjectFile[],
+) => LearningObjectFile {
+  return file => {
+    file.previewUrl = getFilePreviewUrl({
+      authorUsername: learningObject.author.username,
+      learningObjectId: learningObject.id,
+      unreleased: learningObject.status !== LearningObject.Status.RELEASED,
+      fileId: file.id,
+      extension: file.extension,
+    });
+    return file;
+  };
 }
 
 /**
@@ -272,13 +342,20 @@ function handleFileMetadataInsert(
         updates: insert,
       });
       return transformFileMetaToLearningObjectFile({
-        ...existingFile,
-        ...insert,
+        authorUsername: learningObject.author.username,
+        learningObjectId: learningObject.id,
+        file: { ...existingFile, ...insert },
       });
     }
     return Drivers.datastore()
       .insertFileMeta(insert)
-      .then(transformFileMetaToLearningObjectFile);
+      .then(insertedFile =>
+        transformFileMetaToLearningObjectFile({
+          authorUsername: learningObject.author.username,
+          learningObjectId: learningObject.id,
+          file: insertedFile,
+        }),
+      );
   };
 }
 
@@ -457,11 +534,20 @@ export async function deleteFileMeta({
     const fileMeta = await Drivers.datastore().fetchFileMeta(id);
 
     if (!fileMeta) {
-      throw new ResourceError(`Unable to delete file ${id}. File does not exist.`, ResourceErrorReason.NOT_FOUND);
+      throw new ResourceError(
+        `Unable to delete file ${id}. File does not exist.`,
+        ResourceErrorReason.NOT_FOUND,
+      );
     }
 
     await Drivers.datastore().deleteFileMeta(id);
-    Gateways.fileManager().deleteFile({ authorUsername: learningObject.author.username, learningObjectId: learningObject.id, path: fileMeta.fullPath }).catch(reportError);
+    Gateways.fileManager()
+      .deleteFile({
+        authorUsername: learningObject.author.username,
+        learningObjectId: learningObject.id,
+        path: fileMeta.fullPath,
+      })
+      .catch(reportError);
     Gateways.learningObjectGateway().updateObjectLastModifiedDate(
       learningObjectId,
     );
@@ -507,7 +593,13 @@ export async function deleteAllFileMetadata({
     authorizeWriteAccess({ learningObject, requester });
 
     await Drivers.datastore().deleteAllFileMetadata(learningObjectId);
-    Gateways.fileManager().deleteFolder({ authorUsername: learningObject.author.username, learningObjectId: learningObject.id, path: '/' }).catch(reportError);
+    Gateways.fileManager()
+      .deleteFolder({
+        authorUsername: learningObject.author.username,
+        learningObjectId: learningObject.id,
+        path: '/',
+      })
+      .catch(reportError);
   } catch (e) {
     handleError(e);
   }
@@ -517,17 +609,31 @@ export async function deleteAllFileMetadata({
  * Transforms file metadata document into LearningObjectFile
  *
  * @param {FileMetadataDocument} file [File metadata to use to create LearningObjectFile]
+ * @param {string} learningObjectId [Id of the LearningObject the file meta belongs to]
+ * @param {string} authorUsername [Username of the LearningObject's author the file meta belongs to]
  * @returns {LearningObjectFile}
  */
-function transformFileMetaToLearningObjectFile(
-  file: FileMetadataDocument,
-): LearningObjectFile {
+function transformFileMetaToLearningObjectFile({
+  authorUsername,
+  learningObjectId,
+  file,
+}: {
+  authorUsername: string;
+  learningObjectId: string;
+  file: FileMetadataDocument;
+}): LearningObjectFile {
   return {
     id: file.id,
     name: file.name,
     fileType: file.mimeType,
     extension: file.extension,
-    url: '',
+    previewUrl: getFilePreviewUrl({
+      authorUsername,
+      learningObjectId,
+      fileId: file.id,
+      extension: file.extension,
+      unreleased: true,
+    }),
     date: file.lastUpdatedDate,
     fullPath: file.fullPath,
     size: file.size,
@@ -646,4 +752,103 @@ namespace Validators {
   export function valueIsNumber(val: number): boolean {
     return valueDefined(val) && !isNaN(+val);
   }
+}
+
+const MICROSOFT_EXTENSIONS = [
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'odt',
+  'ott',
+  'oth',
+  'odm',
+];
+
+const CAN_PREVIEW = ['pdf', ...MICROSOFT_EXTENSIONS];
+
+/**
+ * Returns preview url for file based on extension
+ * If the file's extension matches a Microsoft file extension, the Microsoft preview url for the file is returned
+ * If the file's extension can be opened in browser, the file's url is returned
+ * If the extension does not match any case, an empty string is returned.
+ *
+ * @export
+ * @param {string} learningObjectId [Id of the LearningObject the file meta belongs to]
+ * @param {string} authorUsername [Username of the LearningObject's author the file meta belongs to]
+ * @param {string} fileId [The id of the file metadata]
+ * @param {string} extension [The file type of the file including the '.' (ie. '.pdf')]
+ *
+ * @returns {string} [Preview url]
+ */
+export function getFilePreviewUrl({
+  authorUsername,
+  learningObjectId,
+  fileId,
+  extension,
+  unreleased,
+}: {
+  authorUsername: string;
+  learningObjectId: string;
+  fileId: string;
+  extension: string;
+  unreleased?: boolean;
+}): string {
+  const extensionType = extension
+    ? extension
+        .trim()
+        .toLowerCase()
+        .replace('.', '')
+    : null;
+  if (CAN_PREVIEW.includes(extensionType)) {
+    if (MICROSOFT_EXTENSIONS.includes(extensionType)) {
+      return generatePreviewUrl({
+        authorUsername,
+        learningObjectId,
+        fileId,
+        unreleased,
+        microsoftPreview: true,
+      });
+    }
+    return generatePreviewUrl({
+      authorUsername,
+      learningObjectId,
+      fileId,
+      unreleased,
+    });
+  }
+  return null;
+}
+
+/**
+ * Generates preview url for a file.
+ *
+ * @param {string} learningObjectId [Id of the LearningObject the file meta belongs to]
+ * @param {string} authorUsername [Username of the LearningObject's author the file meta belongs to]
+ * @param {string} fileId [The id of the file metadata]
+ * @param {boolean} microsoftPreview [Whether or not the file can be previewed using Microsoft's file previewer]
+ * @returns {string}
+ */
+function generatePreviewUrl({
+  learningObjectId,
+  authorUsername,
+  fileId,
+  unreleased,
+  microsoftPreview,
+}: {
+  learningObjectId: string;
+  authorUsername: string;
+  fileId: string;
+  unreleased?: boolean;
+  microsoftPreview?: boolean;
+}): string {
+  let fileSource =
+    `${FILE_API_URI}/users/${authorUsername}/learning-objects/${learningObjectId}/materials/files/${fileId}/download` +
+    `?status=${unreleased ? 'unreleased' : 'released'}`;
+  if (microsoftPreview) {
+    return `${MICROSOFT_PREVIEW_URL}?src=${fileSource}`;
+  }
+  return fileSource + '&open=true';
 }

--- a/src/FileMetadata/gateways/LearningObjectGateway/ModuleLearningObjectGateway.ts
+++ b/src/FileMetadata/gateways/LearningObjectGateway/ModuleLearningObjectGateway.ts
@@ -12,6 +12,17 @@ export class ModuleLearningObjectGateway extends LearningObjectGateway {
   /**
    * @inheritdoc
    *
+   * Proxies `getReleasedLearningObjectSummary` request to LearningObjectAdapter
+   *
+   * @memberof ModuleLearningObjectGateway
+   */
+  getReleasedLearningObjectSummary(id: string): Promise<LearningObjectSummary> {
+    return this.adapter.getReleasedLearningObjectSummary(id);
+  }
+
+  /**
+   * @inheritdoc
+   *
    * Proxies `getWorkingLearningObjectSummary` request to LearningObjectAdapter
    *
    * @memberof ModuleLearningObjectGateway

--- a/src/FileMetadata/interfaces/LearningObjectGateway.ts
+++ b/src/FileMetadata/interfaces/LearningObjectGateway.ts
@@ -6,6 +6,16 @@ import {
 
 export abstract class LearningObjectGateway {
   /**
+   * Retrieves a summary of the released copy Learning Object
+   *
+   * @param {string} id [Id of the Learning Object]
+   * @memberof LearningObjectGateway
+   * @returns {Promise<LearningObjectSummary>}
+   */
+  abstract getReleasedLearningObjectSummary(
+    id: string,
+  ): Promise<LearningObjectSummary>;
+  /**
    * Retrieves a summary of the working copy Learning Object
    *
    * @param {Requester} requester [Object containing information about the requester]

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -707,88 +707,6 @@ export async function getLearningObjectRevisionSummary({
 }
 
 /**
- * Generates new LearningObject.Material.File Object
- *
- * @private
- * @param {FileMeta} file
- * @param {string} url
- * @returns
- */
-function generateLearningObjectFile(
-  file: FileMeta,
-): LearningObject.Material.File {
-  const extension = file.name.split('.').pop();
-  const fileType = file.fileType || '';
-  const learningObjectFile: Partial<LearningObject.Material.File> = {
-    extension,
-    fileType,
-    url: file.url,
-    date: Date.now().toString(),
-    name: file.name,
-    fullPath: file.fullPath,
-    size: +file.size,
-    packageable: isPackageable(+file.size),
-  };
-
-  // Sanitize object. Remove undefined or null values
-  const keys = Object.keys(learningObjectFile);
-  for (const key of keys) {
-    const prop = learningObjectFile[key];
-    if (!prop && prop !== 0) {
-      delete learningObjectFile[key];
-    }
-  }
-
-  return learningObjectFile as LearningObject.Material.File;
-}
-
-// 100 MB in bytes; File size is in bytes
-const MAX_PACKAGEABLE_FILE_SIZE = 100000000;
-function isPackageable(size: number) {
-  // if dztotalfilesize doesn't exist it must not be a chunk upload.
-  // this means by default it must be a packageable file size
-  return !(size > MAX_PACKAGEABLE_FILE_SIZE);
-}
-
-/**
- * Validates all required values are provided for request
- *
- * @param {any[]} params
- * @param {string[]} [mustProvide]
- * @returns {(void | never)}
- */
-function validateRequestParams({
-  params,
-  mustProvide,
-}: {
-  params: any[];
-  mustProvide?: string[];
-}): void | never {
-  const values = [...params].map(val => {
-    if (typeof val === 'string') {
-      val = val.trim();
-    }
-    return val;
-  });
-  if (
-    values.includes(null) ||
-    values.includes('null') ||
-    values.includes(undefined) ||
-    values.includes('undefined') ||
-    values.includes('')
-  ) {
-    const multipleParams = mustProvide.length > 1;
-    let message = 'Invalid parameters provided';
-    if (Array.isArray(mustProvide)) {
-      message = `Must provide ${multipleParams ? '' : 'a'} valid value${
-        multipleParams ? 's' : ''
-      } for ${mustProvide}`;
-    }
-    throw new ResourceError(message, ResourceErrorReason.BAD_REQUEST);
-  }
-}
-
-/**
  * Performs update operation on learning object's date
  *
  * @param {{
@@ -1080,6 +998,16 @@ export async function getLearningObjectById({
     }
     let children: LearningObject[] = [];
     if (loadingReleased) {
+      learningObject.materials.files = learningObject.materials.files.map(
+        file => {
+          file.previewUrl = Gateways.fileMetadata().getFilePreviewUrl({
+            authorUsername: learningObject.author.username,
+            learningObjectId: learningObject.id,
+            file,
+          });
+          return file;
+        },
+      );
       children = await dataStore.loadReleasedChildObjects({
         id: learningObject.id,
         full: false,

--- a/src/LearningObjects/gateways/FileMetadataGateway/ModuleFileMetadataGateway.ts
+++ b/src/LearningObjects/gateways/FileMetadataGateway/ModuleFileMetadataGateway.ts
@@ -8,6 +8,22 @@ export class ModuleFileMetadataGateway implements FileMetadataGateway {
   /**
    * @inheritdoc
    *
+   * Proxies FileMetadataModule's `getFilePreviewUrl`
+   *
+   * @returns {string}
+   * @memberof ModuleFileMetadataGateway
+   */
+  getFilePreviewUrl(params: {
+    authorUsername: string;
+    learningObjectId: string;
+    unreleased: boolean;
+    file: LearningObject.Material.File;
+  }): string {
+    return FileMetadataModule.getFilePreviewUrl(params);
+  }
+  /**
+   * @inheritdoc
+   *
    *
    * Proxies FileMetadataModule's `getAllFileMetadata`
    *

--- a/src/LearningObjects/gateways/FileMetadataGateway/StubFileMetadataGateway.ts
+++ b/src/LearningObjects/gateways/FileMetadataGateway/StubFileMetadataGateway.ts
@@ -4,6 +4,14 @@ import { FileMetadataFilter } from '../../../FileMetadata/typings';
 import { LearningObject } from '../../../shared/entity';
 
 export class StubFileMetadataGateway implements FileMetadataGateway {
+  getFilePreviewUrl(params: {
+    authorUsername: string;
+    learningObjectId: string;
+    unreleased: boolean;
+    file: LearningObject.Material.File;
+  }): string {
+    return '';
+  }
   getAllFileMetadata(params: {
     requester: UserToken;
     learningObjectId: string;

--- a/src/LearningObjects/interfaces/FileMetadataGateway.ts
+++ b/src/LearningObjects/interfaces/FileMetadataGateway.ts
@@ -4,6 +4,23 @@ import { LearningObject } from '../../shared/entity';
 
 export abstract class FileMetadataGateway {
   /**
+   * Retrieves preview url for a given file
+   *
+   * @abstract
+   * @param {string} authorUsername [Username of the author of the LearningObject the file meta belongs to]
+   * @param {string} learningObjectId [Id of the LearningObject the file meta belongs to]
+   * @param {boolean} unreleased [Flag indicating whether or not to return the unreleased preview url]
+   * @param {LearningObject.Material.File} [The file to get a preview url for]
+   * @returns {string}
+   * @memberof FileMetadataGateway
+   */
+  abstract getFilePreviewUrl(params: {
+    authorUsername: string;
+    learningObjectId: string;
+    unreleased?: boolean;
+    file: LearningObject.Material.File;
+  }): string;
+  /**
    * Retrieves all file metadata for a Learning Object
    *
    * @abstract

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -648,7 +648,7 @@ export namespace LearningObject {
       name: string;
       fileType: string;
       extension: string;
-      url: string;
+      previewUrl?: string;
       date: string;
       fullPath?: string;
       size?: number;

--- a/src/shared/types/learning-object-document.ts
+++ b/src/shared/types/learning-object-document.ts
@@ -49,7 +49,6 @@ export interface FileDocument {
   id: string;
   name: string;
   fileType: string;
-  url: string;
   date: string;
 }
 export interface UrlDocument {


### PR DESCRIPTION
**Purpose of this PR**
Fix inconsistencies in file urls and address issue documented in story https://app.clubhouse.io/clarkcan/story/836/no-preview-of-material-available-while-in-material-upload-dashboard-editorial-mode

**Changes in this PR**
- Add function to generate file preview url and return in response when fetching materials, files, and full Learning Objects