### PR TITLE
Ignore build-and-test workflow when merging into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,10 @@ workflows:
   version: 2
   build-test:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore: /master/
 
   build-test-create-sentry-release-and-deploy-production:
     jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.4.0",
+  "version": "3.4.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.4.0",
+  "version": "3.4.0-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {


### PR DESCRIPTION
***Purpose***
This PR is in response to story https://app.clubhouse.io/clarkcan/story/842/only-run-non-deployment-pipeline-on-branches-that-aren-t-master

***Implementation***
Uses the `ignore` option for the master branch

Circle CI branch filtering docs: https://circleci.com/docs/2.0/configuration-reference/#filters-1
