### PR TITLE
Update Mongo connection error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.5.1",
+  "version": "3.5.1-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.5.1",
+  "version": "3.5.1-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {


### PR DESCRIPTION
**Purpose of this PR**
Updates Mongo connect error handling to allow the error to be properly reported to sentry. Additionally, this modifies Mongo connection options to clean up warnings from logs and remove redundant retry limit.

**Changes in this PR**
- Remove wrapping error in rejected promise
- Use new url parser to remove Mongo warnings from logs
- Remove retry limit (Default was already set at 30).