### PR TITLE
Add configurable keep alive timeout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.6.0",
+  "version": "3.6.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.6.0",
+  "version": "3.6.0-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import { ElasticsearchSubmissionPublisher } from './LearningObjectSubmission/Ela
 // ----------------------------------------------------------------------------------
 
 const HTTP_SERVER_PORT = process.env.PORT || '3000';
+const KEEP_ALIVE_TIMEOUT = process.env.KEEP_ALIVE_TIMEOUT;
 
 let dburi: string;
 switch (process.env.NODE_ENV) {
@@ -101,6 +102,9 @@ function initModules() {
  */
 function startHttpServer(app: express.Express): void {
   const server = http.createServer(app);
+  server.keepAliveTimeout = KEEP_ALIVE_TIMEOUT
+    ? parseInt(KEEP_ALIVE_TIMEOUT, 10)
+    : server.keepAliveTimeout;
   server.listen(HTTP_SERVER_PORT, () =>
     console.log(
       `Learning Object Service running on http://localhost:${HTTP_SERVER_PORT}`,


### PR DESCRIPTION
**Purpose of this PR**
This PR is in response to service failures causing 502 Bad Gateway and 504 Gateway Timeout errors. In attempt to fix this issue based on a suggestion in [this](https://adamcrowder.net/posts/node-express-api-and-aws-alb-502/) article, this PR allows the service's server's keep alive timeout widow to be configured.

**Changes in this PR**
- Allows Express server's keep alive time out to be configured by an env variable