### PR TITLE
Fix status filtering when searching all Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.6.0-2",
+  "version": "3.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.6.0-2",
+  "version": "3.6.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -191,15 +191,11 @@ export class MongoDriver implements DataStore {
     if (text) {
       searchQuery.$text = { $search: text };
     }
-    if (status) {
-      searchQuery.$or = searchQuery.$or || [];
-      searchQuery.$or.push({
-        status: { $in: status },
-      });
-    }
+
     const pipeline = this.buildAllObjectsPipeline({
       searchQuery,
       orConditions,
+      status,
       hasText: !!text,
     });
 
@@ -507,6 +503,11 @@ export class MongoDriver implements DataStore {
    * queries provided, then joining the working and released collection together, adding the hasRevision flag to released learning object based on
    * the status of the working object, removing duplicates then returns a filtered and sorted superset of working and released learning objects.
    *
+   * Status filter match stage is applied after initial match stage and creation of the super set in order to avoid filtering out
+   * Learning Objects in the released collection.
+   * ie. status filter = ['released']; Learning Object A is unreleased in `objects` collection and exists in the `released-objects` collection
+   * if this was applied before the collection joining, Learning Object A would not be returned.
+   *
    * @private
    * @param {({
    *     searchQuery?: any;
@@ -520,25 +521,25 @@ export class MongoDriver implements DataStore {
    * @returns {any[]}
    * @memberof MongoDriver
    */
-  private buildAllObjectsPipeline(params: {
+  private buildAllObjectsPipeline({
+    searchQuery,
+    orConditions,
+    hasText,
+    status,
+    page,
+    limit,
+    orderBy,
+    sortType,
+  }: {
     searchQuery?: any;
     orConditions?: any[];
     hasText?: boolean;
+    status?: string[];
     page?: number;
     limit?: number;
     orderBy?: string;
     sortType?: 1 | -1;
   }): any[] {
-    let {
-      searchQuery,
-      orConditions,
-      hasText,
-      page,
-      limit,
-      orderBy,
-      sortType,
-    } = params;
-
     let matcher: any = { ...searchQuery };
     if (orConditions && orConditions.length) {
       matcher.$or = matcher.$or || [];
@@ -585,7 +586,7 @@ export class MongoDriver implements DataStore {
       },
     };
 
-    // create a large filtered collection of learning objects with diplicates.
+    // create a large filtered collection of learning objects with duplicates.
     const createSuperSet = [
       { $unwind: { path: '$released', preserveNullAndEmptyArrays: true } },
       {
@@ -604,6 +605,21 @@ export class MongoDriver implements DataStore {
       },
       ...unWindArrayToRoot,
     ];
+
+    let statusFilterMatch: [
+      { $match: { $or: [{ status: { $in: string[] } }] } }
+    ] = [] as any;
+    if (status) {
+      statusFilterMatch[0] = {
+        $match: {
+          $or: [
+            {
+              status: { $in: status },
+            },
+          ],
+        },
+      };
+    }
 
     // filter and remove duplicates after grouping the objects by ID.
     const removeDuplicates = [
@@ -662,6 +678,7 @@ export class MongoDriver implements DataStore {
       match,
       joinCollections,
       ...createSuperSet,
+      ...statusFilterMatch,
       ...removeDuplicates,
       ...sort,
       {

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -585,6 +585,7 @@ export class LearningObject {
       status: this.status,
       metrics: this.metrics,
       hasRevision: this.hasRevision,
+      revision: this.revision,
     };
     return object;
   }


### PR DESCRIPTION
**Purpose of this PR**
This PR fixes the issue where Learning Objects would not be returned when applying the status filter of `released` if the Learning Object existed in both the `objects` collection and `released-objects` collection and had different statuses.

**Changes in this PR**
Status filter match stage is applied after initial match stage and creation of the super set in order to avoid filtering out Learning Objects in the released collection.