### PR TITLE
Fix Details Page Not Displaying Parents' Names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.0-1",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.0-1",
+  "version": "3.7.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -14,7 +14,7 @@ export function initializePublic({ router, dataStore}: { router: Router, dataSto
         userToken,
         dataStore,
       });
-      res.status(200).send(parents);
+      res.status(200).send(parents.map(obj => obj.toPlainObject()));
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);
       res.status(code).json({message});


### PR DESCRIPTION
The datastore is returning full `LearningObjects`, so this PR puts the mapping stage back in the route handler.