### PR TITLE
Fix TSLint Errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.1-1",
+  "version": "3.7.1-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.7.1-1",
+  "version": "3.7.1-2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
+++ b/src/LearningObjects/Hierarchy/HierarchyRouteHandler.ts
@@ -3,17 +3,19 @@ import { DataStore } from '../../shared/interfaces/DataStore';
 import { LearningObjectInteractor } from '../../interactors/interactors';
 import { fetchParents } from './HierarchyInteractor';
 import { mapErrorToResponseData } from '../../shared/errors';
+import { LearningObject } from '../../shared/entity';
 
 export function initializePublic({ router, dataStore}: { router: Router, dataStore: DataStore }) {
   const getParents = async (req: Request, res: Response) => {
     try {
       const userToken = req.user;
 
+      // FIXME: this is returning LearningObjects even though it should return summaries
       const parents = await fetchParents({
         learningObjectID: req.params.id,
         userToken,
         dataStore,
-      });
+      }) as LearningObject[];
       res.status(200).send(parents.map(obj => obj.toPlainObject()));
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);


### PR DESCRIPTION
The datastore is currently returning a full Learning Object even when it shouldn't (see #438). This PR adds typecasting in to the route handler that is dealing with this so that `tsc` can run without errors. This restores the `npm start` command.