### PR TITLE
Point search traffic to Elastic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.8.6",
+  "version": "3.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.8.5",
+  "version": "3.8.6",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.8.6",
+  "version": "3.9.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -420,7 +420,7 @@ export class LearningObjectInteractor {
         status,
       } = this.formatSearchQuery(query);
       let response: { total: number; objects: LearningObject[] };
-      console.log('Hitting the learning object interactor');
+
       if (userToken && requesterIsPrivileged(userToken)) {
         let conditions: QueryCondition[];
         if (!requesterIsAdminOrEditor(userToken)) {

--- a/src/interactors/LearningObjectInteractor.ts
+++ b/src/interactors/LearningObjectInteractor.ts
@@ -420,7 +420,7 @@ export class LearningObjectInteractor {
         status,
       } = this.formatSearchQuery(query);
       let response: { total: number; objects: LearningObject[] };
-
+      console.log('Hitting the learning object interactor');
       if (userToken && requesterIsPrivileged(userToken)) {
         let conditions: QueryCondition[];
         if (!requesterIsAdminOrEditor(userToken)) {


### PR DESCRIPTION
This PR directs all user traffic to the Elastic search index, expect in the case where an author is searching/viewing objects in their dashboard. 