### PR TITLE
Fix bug where submission ReadMe files are not populated with files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.11.1",
+  "version": "3.11.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.11.1",
+  "version": "3.11.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjectSubmission/gateways/FileMetadataGateway/ModuleFileMetadataGateway.ts
+++ b/src/LearningObjectSubmission/gateways/FileMetadataGateway/ModuleFileMetadataGateway.ts
@@ -1,0 +1,24 @@
+import { FileMetadataGateway } from '../../interfaces/FileMetadataGateway';
+import { UserToken } from '../../../shared/types';
+import { FileMetadataFilter } from '../../../FileMetadata/typings';
+import { LearningObject } from '../../../shared/entity';
+import { FileMetadataModule } from '../../../FileMetadata/FileMetadataModule';
+
+export class ModuleFileMetadataGateway implements FileMetadataGateway {
+  /**
+   * @inheritdoc
+   *
+   *
+   * Proxies FileMetadataModule's `getAllFileMetadata`
+   *
+   * @returns {Promise<LearningObject.Material.File>}
+   * @memberof ModuleFileMetadataGateway
+   */
+  getAllFileMetadata(params: {
+    requester: UserToken;
+    learningObjectId: string;
+    filter: FileMetadataFilter;
+  }): Promise<LearningObject.Material.File[]> {
+    return FileMetadataModule.getAllFileMetadata(params);
+  }
+}

--- a/src/LearningObjectSubmission/interactors/submitForReview.ts
+++ b/src/LearningObjectSubmission/interactors/submitForReview.ts
@@ -65,6 +65,7 @@ async function updateLearningObjectFields(params: { user: UserToken; learningObj
   });
   await LearningObjectGateway.updateReadme({
     id: params.learningObjectId,
+    requester: params.user,
   });
 }
 

--- a/src/LearningObjectSubmission/interfaces/FileMetadataGateway.ts
+++ b/src/LearningObjectSubmission/interfaces/FileMetadataGateway.ts
@@ -1,0 +1,20 @@
+import { UserToken } from '../../shared/types';
+import { FileMetadataFilter } from '../../FileMetadata/typings';
+import { LearningObject } from '../../shared/entity';
+
+export abstract class FileMetadataGateway {
+  /**
+   * Retrieves all file metadata for a Learning Object
+   *
+   * @abstract
+   * @param {UserToken} requester [Information about the requester]
+   * @param {string} learningObjectId [Id of the LearningObject the file meta belongs to]
+   *
+   * @returns {Promise<LearningObject.Material.File>}
+   */
+  abstract getAllFileMetadata(params: {
+    requester: UserToken;
+    learningObjectId: string;
+    filter: FileMetadataFilter;
+  }): Promise<LearningObject.Material.File[]>;
+}

--- a/src/LearningObjects/adapters/LearningObjectAdapter.ts
+++ b/src/LearningObjects/adapters/LearningObjectAdapter.ts
@@ -172,12 +172,14 @@ export class LearningObjectAdapter {
    */
   async updateReadme(params: {
     object?: LearningObject;
+    requester: UserToken;
     id?: string;
   }): Promise<void> {
     return updateReadme({
       dataStore: this.dataStore,
       object: params.object,
       id: params.id,
+      requester: params.requester,
     });
   }
 

--- a/src/drivers/express/ExpressAuthRouteDriver.ts
+++ b/src/drivers/express/ExpressAuthRouteDriver.ts
@@ -104,6 +104,7 @@ export class ExpressAuthRouteDriver {
       try {
         const id = req.params.id;
         await updateReadme({
+          requester: req.user,
           id,
           dataStore: this.dataStore,
         });


### PR DESCRIPTION
***Purpose***
Populate submission readme files with file metadata

***Implementation***
Use the file metadata gateway in the Learning Objects module interactor to fetch files before readme generation

***Story***
This story responds to Clubhouse story https://app.clubhouse.io/clarkcan/story/1047/fix-bug-where-submission-readme-files-were-not-populated-with-files