### PR TITLE
Add URI's to Learning Objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -259,9 +259,9 @@ export async function getLearningObjectByName({
 
     const resourceUriHost = process.env.GATEWAY_API;
 
-    learningObject.resourceUris.children = `${resourceUriHost}/learning-objects/${learningObject.id}/children/summmary`;
-    learningObject.resourceUris.materials = `${resourceUriHost}/users/:username/learning-objects/${learningObject.id}/materials`;
-    learningObject.resourceUris.metrics = `${resourceUriHost}/learning-objects/${learningObject.id}/metrics`;
+    learningObject.resourceUris.children = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/children`;
+    learningObject.resourceUris.materials = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/materials`;
+    learningObject.resourceUris.metrics = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/metrics`;
     learningObject.resourceUris.parents = `${resourceUriHost}/learning-objects/${learningObject.id}/parents`;
     learningObject.resourceUris.ratings = `${resourceUriHost}/learning-objects/${learningObject.id}/ratings`;
 

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -259,6 +259,7 @@ export async function getLearningObjectByName({
 
     const resourceUriHost = process.env.GATEWAY_API;
 
+    learningObject.resourceUris.outcomes = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/children`;
     learningObject.resourceUris.children = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/children`;
     learningObject.resourceUris.materials = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/materials`;
     learningObject.resourceUris.metrics = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/metrics`;

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -251,19 +251,7 @@ export async function getLearningObjectByName({
       });
     }
 
-    // attach additional properties
-    if (!learningObject.resourceUris) {
-      learningObject.resourceUris = {};
-    }
-
-    const resourceUriHost = process.env.GATEWAY_API;
-
-    learningObject.resourceUris.outcomes = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/children`;
-    learningObject.resourceUris.children = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/children`;
-    learningObject.resourceUris.materials = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/materials`;
-    learningObject.resourceUris.metrics = `${resourceUriHost}/users/${learningObject.author.username}/learning-objects/${learningObject.id}/metrics`;
-    learningObject.resourceUris.parents = `${resourceUriHost}/learning-objects/${learningObject.id}/parents`;
-    learningObject.resourceUris.ratings = `${resourceUriHost}/learning-objects/${learningObject.id}/ratings`;
+    learningObject.attachResourceUris(process.env.GATEWAY_API);
 
     return learningObject;
   } catch (e) {
@@ -1087,6 +1075,9 @@ export async function getLearningObjectById({
       reportError(e);
       return { saves: 0, downloads: 0 };
     });
+
+    learningObject.attachResourceUris(process.env.GATEWAY_API);
+
     return learningObject;
   } catch (e) {
     handleError(e);
@@ -1152,6 +1143,8 @@ export async function getLearningObjectSummaryById({
       authorUsername: learningObject.author.username,
       released: loadingReleased,
     });
+
+    learningObject.attachResourceUris(process.env.GATEWAY_API);
 
     return mapLearningObjectToSummary(learningObject);
   } catch (e) {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -57,6 +57,8 @@ import { LearningObjectSubmissionAdapter } from '../LearningObjectSubmission/ada
 import { UserGateway } from './interfaces/UserGateway';
 import { validateUpdates } from '../shared/entity/learning-object/validators';
 
+const GATEWAY_API = process.env.GATEWAY_API;
+
 namespace Drivers {
   export const readMeBuilder = () =>
     LearningObjectsModule.resolveDependency(ReadMeBuilder);
@@ -251,7 +253,7 @@ export async function getLearningObjectByName({
       });
     }
 
-    learningObject.attachResourceUris(process.env.GATEWAY_API);
+    learningObject.attachResourceUris(GATEWAY_API);
 
     return learningObject;
   } catch (e) {
@@ -1076,7 +1078,7 @@ export async function getLearningObjectById({
       return { saves: 0, downloads: 0 };
     });
 
-    learningObject.attachResourceUris(process.env.GATEWAY_API);
+    learningObject.attachResourceUris(GATEWAY_API);
 
     return learningObject;
   } catch (e) {
@@ -1144,7 +1146,7 @@ export async function getLearningObjectSummaryById({
       released: loadingReleased,
     });
 
-    learningObject.attachResourceUris(process.env.GATEWAY_API);
+    learningObject.attachResourceUris(GATEWAY_API);
 
     return mapLearningObjectToSummary(learningObject);
   } catch (e) {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -55,6 +55,7 @@ import { LearningObjectsModule } from './LearningObjectsModule';
 import { LearningObjectSubmissionAdapter } from '../LearningObjectSubmission/adapters/LearningObjectSubmissionAdapter';
 import { UserGateway } from './interfaces/UserGateway';
 import { validateUpdates } from '../shared/entity/learning-object/validators';
+import { LIBRARY_ROUTES as LibraryRoutes } from '../shared/routes';
 
 namespace Drivers {
   export const readMeBuilder = () =>
@@ -249,6 +250,19 @@ export async function getLearningObjectByName({
         userToken,
       });
     }
+
+    // attach additional properties
+    if (!learningObject.resourceUris) {
+      learningObject.resourceUris = {};
+    }
+
+    const resourceUriHost = process.env.GATEWAY_API;
+
+    learningObject.resourceUris.children = `${resourceUriHost}/learning-objects/${learningObject.id}/children/summmary`;
+    learningObject.resourceUris.materials = `${resourceUriHost}/users/:username/learning-objects/${learningObject.id}/materials`;
+    learningObject.resourceUris.metrics = `${resourceUriHost}/learning-objects/${learningObject.id}/metrics`;
+    learningObject.resourceUris.parents = `${resourceUriHost}/learning-objects/${learningObject.id}/parents`;
+    learningObject.resourceUris.ratings = `${resourceUriHost}/learning-objects/${learningObject.id}/ratings`;
 
     return learningObject;
   } catch (e) {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -56,7 +56,6 @@ import { LearningObjectsModule } from './LearningObjectsModule';
 import { LearningObjectSubmissionAdapter } from '../LearningObjectSubmission/adapters/LearningObjectSubmissionAdapter';
 import { UserGateway } from './interfaces/UserGateway';
 import { validateUpdates } from '../shared/entity/learning-object/validators';
-import { LIBRARY_ROUTES as LibraryRoutes } from '../shared/routes';
 
 namespace Drivers {
   export const readMeBuilder = () =>

--- a/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
@@ -266,7 +266,7 @@ export function initializePrivate({
     deleteLearningObjectByName,
   );
   router.get('/users/:username/learning-objects/:id/materials', getMaterials);
-  router.get('/learning-objects/:id/materials/all', getMaterials);
+  router.get('/users/:username/learning-objects/:id/materials/all', getMaterials);
   router.get(
     '/learning-objects/:id/children/summary',
     getLearningObjectChildren,

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -11,6 +11,16 @@ import { LearningObjectSummary, LearningObjectChildSummary } from '../../types';
 const MIN_NAME_LENGTH = 3;
 const MAX_NAME_LENGTH = 170;
 
+type LearningObjectResourceUris = {
+  outcomes?: string;
+  children?: string;
+  materials?: string;
+  metrics?: string;
+  parents?: string;
+  ratings?: string;
+  [key: string]: string;
+};
+
 /**
  * A class to represent a learning object.
  * @class
@@ -404,10 +414,9 @@ export class LearningObject {
   /**
    * Store's URI's to additional pieces of the Learning Object to be fetched asynchronously
    *
-   * @type {{ [key: string]: string }}
    * @memberof LearningObject
    */
-  resourceUris?: { [key: string]: string };
+  resourceUris?: LearningObjectResourceUris;
 
   /**
    * Map deprecated status values to new LearningObject.Status values

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -18,7 +18,6 @@ export type LearningObjectResourceUris = {
   metrics?: string;
   parents?: string;
   ratings?: string;
-  [key: string]: string;
 };
 
 /**
@@ -420,39 +419,23 @@ export class LearningObject {
 
   attachResourceUris(
     resourceUriHost: string,
-    properties?: { [P in keyof LearningObjectResourceUris]: boolean },
-    overrides?: LearningObjectResourceUris,
   ) {
     // attach additional properties
     if (!this.resourceUris) {
       this.resourceUris = {};
     }
 
-    if (!properties || properties.outcomes) {
-      this.resourceUris.outcomes = overrides && overrides.outcomes ? overrides.outcomes : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/outcomes`;
-    }
+    this.resourceUris.outcomes = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/outcomes`;
 
-    if (!properties || properties.children) {
-      this.resourceUris.children = overrides && overrides.children ? overrides.children : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
-    }
+    this.resourceUris.children = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
 
-    if (!properties || properties.materials) {
-      this.resourceUris.materials = overrides && overrides.materials ?
-        overrides.materials :
-        `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials`;
-    }
+    this.resourceUris.materials = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials`;
 
-    if (!properties || properties.metrics) {
-      this.resourceUris.metrics = overrides && overrides.metrics ? overrides.metrics : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
-    }
+    this.resourceUris.metrics = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
 
-    if (!properties || properties.parents) {
-      this.resourceUris.parents = overrides && overrides.parents ? overrides.parents : `${resourceUriHost}/learning-objects/${this.id}/parents`;
-    }
+    this.resourceUris.parents = `${resourceUriHost}/learning-objects/${this.id}/parents`;
 
-    if (!properties || properties.ratings) {
-      this.resourceUris.ratings = overrides && overrides.ratings ? overrides.ratings : `${resourceUriHost}/learning-objects/${this.id}/ratings`;
-    }
+    this.resourceUris.ratings = `${resourceUriHost}/learning-objects/${this.id}/ratings`;
   }
 
   /**

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -402,6 +402,14 @@ export class LearningObject {
   }
 
   /**
+   * Store's URI's to additional pieces of the Learning Object to be fetched asynchronously
+   *
+   * @type {{ [key: string]: string }}
+   * @memberof LearningObject
+   */
+  resourceUris?: { [key: string]: string };
+
+  /**
    * Map deprecated status values to new LearningObject.Status values
    *
    * @private
@@ -560,6 +568,7 @@ export class LearningObject {
       metrics: this.metrics,
       hasRevision: this.hasRevision,
       revision: this.revision,
+      resourceUris: this.resourceUris,
     };
     return object;
   }

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -417,6 +417,12 @@ export class LearningObject {
    */
   resourceUris?: LearningObjectResourceUris;
 
+  /**
+   * Attach URIs of additional resources to the Learning Object
+   *
+   * @param {string} resourceUriHost the base URI of the api
+   * @memberof LearningObject
+   */
   attachResourceUris(
     resourceUriHost: string,
   ) {

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -11,7 +11,7 @@ import { LearningObjectSummary, LearningObjectChildSummary } from '../../types';
 const MIN_NAME_LENGTH = 3;
 const MAX_NAME_LENGTH = 170;
 
-type LearningObjectResourceUris = {
+export type LearningObjectResourceUris = {
   outcomes?: string;
   children?: string;
   materials?: string;
@@ -417,6 +417,43 @@ export class LearningObject {
    * @memberof LearningObject
    */
   resourceUris?: LearningObjectResourceUris;
+
+  attachResourceUris(
+    resourceUriHost: string,
+    properties?: { [P in keyof LearningObjectResourceUris]: boolean },
+    overrides?: LearningObjectResourceUris,
+  ) {
+    // attach additional properties
+    if (!this.resourceUris) {
+      this.resourceUris = {};
+    }
+
+    if (!properties || properties.outcomes) {
+      this.resourceUris.outcomes = overrides && overrides.outcomes ? overrides.outcomes : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/outcomes`;
+    }
+
+    if (!properties || properties.children) {
+      this.resourceUris.children = overrides && overrides.children ? overrides.children : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
+    }
+
+    if (!properties || properties.materials) {
+      this.resourceUris.materials = overrides && overrides.materials ?
+        overrides.materials :
+        `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials`;
+    }
+
+    if (!properties || properties.metrics) {
+      this.resourceUris.metrics = overrides && overrides.metrics ? overrides.metrics : `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
+    }
+
+    if (!properties || properties.parents) {
+      this.resourceUris.parents = overrides && overrides.parents ? overrides.parents : `${resourceUriHost}/learning-objects/${this.id}/parents`;
+    }
+
+    if (!properties || properties.ratings) {
+      this.resourceUris.ratings = overrides && overrides.ratings ? overrides.ratings : `${resourceUriHost}/learning-objects/${this.id}/ratings`;
+    }
+  }
 
   /**
    * Map deprecated status values to new LearningObject.Status values

--- a/src/shared/functions/index.ts
+++ b/src/shared/functions/index.ts
@@ -132,6 +132,7 @@ export function mapLearningObjectToSummary(
     name: object.name,
     revision: object.revision,
     status: object.status,
+    resourceUris: object.resourceUris,
   };
 }
 

--- a/src/shared/types/learning-object-summary.ts
+++ b/src/shared/types/learning-object-summary.ts
@@ -1,4 +1,4 @@
-import { LearningObjectResourceUris } from "../entity/learning-object/learning-object";
+import { LearningObjectResourceUris } from '../entity/learning-object/learning-object';
 
 /**
  * An interface representation of the AuthorSummary type

--- a/src/shared/types/learning-object-summary.ts
+++ b/src/shared/types/learning-object-summary.ts
@@ -1,3 +1,5 @@
+import { LearningObjectResourceUris } from "../entity/learning-object/learning-object";
+
 /**
  * An interface representation of the AuthorSummary type
  *
@@ -67,6 +69,11 @@ export interface LearningObjectChildSummary {
    * The stage within the review pipeline that the Learning Object exists
    */
   status: string;
+
+  /**
+   * Optional URIs that point to other pieces of the Learning Object (such as children and materials)
+   */
+  resourceUris?: LearningObjectResourceUris;
 }
 /**
  * An interface representation of the full learning object summary with the revision information included.


### PR DESCRIPTION
This PR introduces a `resourceUris` property on Learning Objects returned from the `/learning-objects/:authorUsername/:learningObjectName` route. It can contain an object where each key corresponds to a property on the Learning Object and the value for each key is a URI for fetching that property. 

This will enable to details page (and other areas of the application as this pattern permeates through the system) to handle outages more gracefully, load different pieces of a single view asynchronously, and stop over-fetching data.

**Sample Response**
![Screen Shot 2019-08-30 at 1 14 56 PM](https://user-images.githubusercontent.com/7431390/64039236-2b792200-cb28-11e9-9064-6d57f9625020.png)
