### PR TITLE
Convert Revision Query String to boolean

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/adapters/ExpressHttpAdapter.ts
+++ b/src/FileManager/adapters/ExpressHttpAdapter.ts
@@ -58,11 +58,15 @@ async function download(req: Request, res: Response) {
 
 async function getLearningObjectBundle(req: Request, res: Response) {
   try {
+    let revision = false;
+    if (req.query.revision === '') {
+      revision = true;
+    }
     const stream = await downloadBundle({
       requester: req.user,
       learningObjectAuthorUsername: req.params.username,
       learningObjectId: req.params.learningObjectName,
-      revision: req.query.revision,
+      revision,
     });
     stream.pipe(res);
   } catch (e) {


### PR DESCRIPTION
***Purpose***
This PR adds functionality to the /bundle route to interpret the presence of a revision query string and translate it to a boolean. This allows the client to use a more restful route convention.