### PR TITLE
Remove zero byte file check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileMetadata/Interactor.ts
+++ b/src/FileMetadata/Interactor.ts
@@ -708,11 +708,6 @@ function validateFileMeta(file: FileMetadata) {
     invalidInput.message = 'File metadata must contain a file name.';
     throw invalidInput;
   }
-  if (!Validators.valueIsNumber(file.size)) {
-    invalidInput.message =
-      'File metadata must have a defined file size greater than zero.';
-    throw invalidInput;
-  }
 }
 
 namespace Validators {


### PR DESCRIPTION
This PR removes the zero-byte file check since it throws errors after the uploads complete and is not something that is necessarily indicative of a corrupted file.