### PR TITLE
Stream Bundle with Learning Object Name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2-1",
+  "version": "3.18.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2-1",
+  "version": "3.18.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/adapters/ExpressHttpAdapter.ts
+++ b/src/FileManager/adapters/ExpressHttpAdapter.ts
@@ -68,6 +68,7 @@ async function getLearningObjectBundle(req: Request, res: Response) {
       learningObjectId: req.params.learningObjectName,
       revision,
     });
+    res.header('Content-Disposition', `attachment; filename="${req.params.learningObjectName}.zip"`);
     stream.pipe(res);
   } catch (e) {
     const { code, message } = mapErrorToResponseData(e);

--- a/src/FileManager/interactors/downloadBundle.ts
+++ b/src/FileManager/interactors/downloadBundle.ts
@@ -80,7 +80,7 @@ async function downloadReleasedCopy(
     authorUsername: learningObjectAuthorUsername,
     learningObjectId: learningObject.id,
     learningObjectRevisionId: learningObject.revision,
-    path: 'bundle.zip',
+    path: `${learningObject.cuid}.zip`,
   });
 
   if (!fileExists) {
@@ -90,7 +90,7 @@ async function downloadReleasedCopy(
       learningObjectId: learningObject.id,
       learningObjectRevisionId: learningObject.revision,
       file: {
-        path: 'bundle.zip',
+        path: `${learningObject.cuid}.zip`,
         data: bundle,
       },
     });
@@ -100,7 +100,7 @@ async function downloadReleasedCopy(
     authorUsername: learningObjectAuthorUsername,
     learningObjectId: learningObject.id,
     learningObjectRevisionId: learningObject.revision,
-    path: 'bundle.zip',
+    path: `${learningObject.cuid}.zip`,
   });
 }
 

--- a/src/LearningObjects/Publishing/interactor.ts
+++ b/src/LearningObjects/Publishing/interactor.ts
@@ -93,7 +93,7 @@ async function createPublishingArtifacts(
     learningObjectId: releasableObject.id,
     learningObjectRevisionId: releasableObject.revision,
     file: {
-      path: 'bundle.zip',
+      path: `${releasableObject.cuid}.zip`,
       data: bundle,
     },
   });


### PR DESCRIPTION
***Purpose***
Currently, every download is streamed to the client with a filename of `bundle.zip`. This is confusing when downloading multiple Learning Objects. This PR changes the name of the .zip file to Learning Object Name.zip before it is streamed to the client. 

As of yesterday, bundles are stored internally as CUID.zip. This change allows us to avoid collisions with user file names.

- This PR points to those newly named bundles. 
- The release process was also updated to generate bundles with the name CUID.zip

***Implementation***
In order to dynamically change file names during the download process, this header was added
 `res.header('Content-Disposition', attachment; filename="${req.params.learningObjectName}.zip");`

***Story***
Clubhouse story https://app.clubhouse.io/clarkcan/story/1239/change-name-of-bundle-zip-to-cuid-zip