### PR TITLE
Fix bugs related to URIs in entity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2",
+  "version": "3.17.2-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2-1",
+  "version": "3.17.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2-1",
+  "version": "3.17.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.17.2",
+  "version": "3.17.2-1",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/FileManager/drivers/FileManager/S3FileManager.ts
+++ b/src/FileManager/drivers/FileManager/S3FileManager.ts
@@ -208,7 +208,7 @@ export class S3FileManager implements FileManager {
       .on('error', (err: AWSError) => {
         // TimeoutError will be thrown if the client cancels the download
         if (err.code !== 'TimeoutError') {
-          reportError(err);
+          reportError({...err, message: `${err.message} occured when looking for key ${path}`} as Error);
         }
       });
     return stream;

--- a/src/LearningOutcomes/LearningOutcomeRouteHandler.ts
+++ b/src/LearningOutcomes/LearningOutcomeRouteHandler.ts
@@ -28,7 +28,7 @@ export function initializePublic({
       const requester = req.user;
 
       const outcomes = await LearningOutcomeInteractor.getAllLearningOutcomes({ dataStore, requester, source, learningObjectGateway: getLearningObjectGateway() });
-      res.status(200).json(outcomes);
+      res.status(200).json(outcomes.map(o => o.toPlainObject()));
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);
       res.status(code).json({message});

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -471,7 +471,7 @@ export class LearningObject {
     this.resourceUris.children = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
 
     // tslint:disable-next-line: max-line-length
-    this.resourceUris.materials = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials?status=${this.status === LearningObject.Status.UNRELEASED ? LearningObject.Status.UNRELEASED : ''}`;
+    this.resourceUris.materials = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials?status=${this.status !== LearningObject.Status.RELEASED ? LearningObject.Status.UNRELEASED : ''}`;
 
     this.resourceUris.metrics = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
 

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -470,7 +470,11 @@ export class LearningObject {
 
     this.resourceUris.children = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
 
-    this.resourceUris.materials = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials`;
+    this.resourceUris.materials = `
+      ${resourceUriHost}
+      /users/${this.author.username}
+      /learning-objects/${this.id}
+      /materials?status=${this.status === LearningObject.Status.UNRELEASED ? LearningObject.Status.UNRELEASED : ''}`;
 
     this.resourceUris.metrics = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
 

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -470,11 +470,8 @@ export class LearningObject {
 
     this.resourceUris.children = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/children`;
 
-    this.resourceUris.materials = `
-      ${resourceUriHost}
-      /users/${this.author.username}
-      /learning-objects/${this.id}
-      /materials?status=${this.status === LearningObject.Status.UNRELEASED ? LearningObject.Status.UNRELEASED : ''}`;
+    // tslint:disable-next-line: max-line-length
+    this.resourceUris.materials = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/materials?status=${this.status === LearningObject.Status.UNRELEASED ? LearningObject.Status.UNRELEASED : ''}`;
 
     this.resourceUris.metrics = `${resourceUriHost}/users/${this.author.username}/learning-objects/${this.id}/metrics`;
 


### PR DESCRIPTION
This PR does two things:

1) Fixes a bug where Learning Outcomes are returned as constructed instances of LearningOutcome instead of as plain JS objects

2) Fixes a bug where materials cannot be fetched from the URI if the object is not released.