### PR TITLE
Mimic call structure from document learning objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.20.1",
+  "version": "3.20.2",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/shared/MongoDB/HelperFunctions/documentReleasedLearningObject/documentReleasedLearningObject.ts
+++ b/src/shared/MongoDB/HelperFunctions/documentReleasedLearningObject/documentReleasedLearningObject.ts
@@ -1,6 +1,7 @@
 import { LearningObject } from '../../../entity';
 import { LearningObjectDocument } from '../../../types';
 import { ReleasedLearningObjectDocument } from '../../../types/learning-object-document';
+import { UserServiceGateway } from '../../../gateways/user-service/UserServiceGateway';
 
 /**
  * Converts Released Learning Object to Document
@@ -15,17 +16,18 @@ import { ReleasedLearningObjectDocument } from '../../../types/learning-object-d
 export async function documentReleasedLearningObject(
   object: LearningObject,
 ): Promise<LearningObjectDocument> {
+  const authorID = await UserServiceGateway.getInstance().findUser(object.author.username);
   let contributorIds: string[] = [];
 
   if (object.contributors && object.contributors.length) {
     contributorIds = await Promise.all(
-      object.contributors.map(user => this.findUser(user.username)),
+      object.contributors.map(user => UserServiceGateway.getInstance().findUser(user.username)),
     );
   }
 
   const doc: ReleasedLearningObjectDocument = {
     _id: object.id,
-    authorID: object.author.id,
+    authorID: authorID,
     name: object.name,
     date: object.date,
     length: object.length,


### PR DESCRIPTION
Update documentReleasedObject to use the pattern used for documentObject so that sentry doesn't throw any cannot find function errors.