### PR TITLE
Implement route to fetch versions of a Learning Object CUID and version number

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.20.2",
+  "version": "3.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "3.20.2",
+  "version": "3.21.0",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -122,6 +122,43 @@ export async function getLearningObjectByName({
 }
 
 /**
+ * Retrieve a Learning Object by CUID
+ *
+ * This function returns all versions of the Learning Object that the requester is authorized to read.
+ *
+ * @export
+ * @param {{
+ *   dataStore: DataStore,
+ *   requester: UserToken,
+ *   authorUsername: string,
+ *   cuid: string,
+ *   version?: number,
+ * }}
+ * @returns
+ */
+export async function getLearningObjectByCuid({
+  dataStore,
+  requester,
+  cuid,
+  version,
+}: {
+  dataStore: DataStore,
+  requester: UserToken,
+  authorUsername: string,
+  cuid: string,
+  version?: number,
+}) {
+  const objects = await dataStore.fetchLearningObjectByCuid(cuid, version);
+  const payload = objects.filter(object => {
+    // this function will throw a ResourceError if requester isn't authorized
+    authorizeReadAccess({ learningObject: object, requester });
+    return true;
+  });
+
+  return payload;
+}
+
+/**
  * Loads working copy of a Learning Object by author's username and Learning Object's name
  *
  * @private
@@ -1444,10 +1481,10 @@ export async function createLearningObjectRevision(params: {
 function appendFilePreviewUrls(
   learningObject: LearningObject,
 ): (
-  value: LearningObject.Material.File,
-  index: number,
-  array: LearningObject.Material.File[],
-) => LearningObject.Material.File {
+    value: LearningObject.Material.File,
+    index: number,
+    array: LearningObject.Material.File[],
+  ) => LearningObject.Material.File {
   return file => {
     file.previewUrl = Gateways.fileMetadata().getFilePreviewUrl({
       authorUsername: learningObject.author.username,

--- a/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
@@ -102,6 +102,31 @@ export function initializePublic({
       res.status(code).json({ message });
     }
   };
+
+  const getLearningObjectByCuid = async (req: Request, res: Response, next: any) => {
+    try {
+      const cuid = req.params.cuid;
+      const requester = req.user;
+      const authorUsername = req.params.username;
+      const version = req.query.version;
+
+      if (cuid.indexOf('-') === -1) {
+        // this isn't a CUID, fall through to learning object :id
+        next();
+        return;
+      }
+
+      const results = await LearningObjectInteractor.getLearningObjectByCuid({ dataStore, requester, authorUsername, cuid, version });
+
+      res.json(results);
+    } catch (e) {
+      const { code, message } = mapErrorToResponseData(e);
+      res.status(code).json({ message });
+    }
+  };
+
+  router.get('/users/:username/learning-objects/:cuid', getLearningObjectByCuid)
+
   /**
    * @deprecated This route will be deprecated because of its non RESTful route structure
    * Please update to using `/users/:username/learning-objects/:learningObjectId`

--- a/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
@@ -125,7 +125,7 @@ export function initializePublic({
     }
   };
 
-  router.get('/users/:username/learning-objects/:cuid', getLearningObjectByCuid)
+  router.get('/users/:username/learning-objects/:cuid', getLearningObjectByCuid);
 
   /**
    * @deprecated This route will be deprecated because of its non RESTful route structure

--- a/src/shared/MongoDB/HelperFunctions/generateLearningObject/generateLearningObject.ts
+++ b/src/shared/MongoDB/HelperFunctions/generateLearningObject/generateLearningObject.ts
@@ -64,5 +64,8 @@ export async function generateLearningObject(
     children,
     revision: record.revision,
   });
+
+  learningObject.attachResourceUris(process.env.GATEWAY_API);
+
   return learningObject;
 }

--- a/src/shared/entity/learning-object/learning-object.ts
+++ b/src/shared/entity/learning-object/learning-object.ts
@@ -525,7 +525,7 @@ export class LearningObject {
    * @param {Partial<LearningObject>} [object]
    * @memberof LearningObject
    */
-  constructor(object?: Partial<LearningObject>) {
+  constructor(object?: Partial<LearningObject> | any) {
     // @ts-ignore Id will be undefined on creation
     this._id = undefined;
     this._cuid = undefined;
@@ -561,7 +561,7 @@ export class LearningObject {
    * @param {Partial<LearningObject>} object
    * @memberof LearningObject
    */
-  private copyObject(object: Partial<LearningObject>): void {
+  private copyObject(object: Partial<LearningObject> | any): void {
     if (object.id) {
       this.id = object.id;
     }

--- a/src/shared/interfaces/DataStore.ts
+++ b/src/shared/interfaces/DataStore.ts
@@ -183,6 +183,8 @@ export interface DataStore
   deleteChild(parentId: string, childId: string): Promise<void>;
   addToCollection(learningObjectId: string, collection: string): Promise<void>;
 
+  fetchLearningObjectByCuid(cuid: string, version?: number): Promise<LearningObjectSummary[]>;
+
   /*
    * DELETE Operations
    */

--- a/src/tests/mock-drivers/MockDataStore.ts
+++ b/src/tests/mock-drivers/MockDataStore.ts
@@ -456,4 +456,9 @@ export class MockDataStore implements DataStore, SubmissionDataStore {
   findParentObjectId(params: { childId: string }): Promise<string> {
     return Promise.resolve(this.stubs.learningObject.id);
   }
+
+  fetchLearningObjectByCuid(cuid: string, version?: number) {
+    return Promise.resolve([this.stubs.learningObject]);
+  }
+
 }


### PR DESCRIPTION
This PR introduces a route to fetch a Learning Object by CUID and Version number. It's backwards compatible with the `/users/:username/learning-objects/:id` route. This PR also changes the LearningObject constructor function to take any object instead of only a `Partial<LearningObject>`