### PR TITLE
Fix Downloads Counter

### DIFF
--- a/src/FileManager/drivers/LearningObjectDownloads/learningObjectLibraryDownload.ts
+++ b/src/FileManager/drivers/LearningObjectDownloads/learningObjectLibraryDownload.ts
@@ -1,5 +1,6 @@
 import { COLLECTIONS } from '../../../drivers/MongoDriver';
 import { MongoConnector } from '../../../shared/MongoDB/MongoConnector';
+import { LearningObjectSummary } from '../../../shared/types';
 
 /**
  * Appends the downloaded boolean to the document in the users library on download
@@ -8,25 +9,23 @@ import { MongoConnector } from '../../../shared/MongoDB/MongoConnector';
  */
 export async function updateObjectInLibraryForDownload(
     username: string,
-    id: string,
+    learningObject: LearningObjectSummary,
 ): Promise<void> {
-    console.log(username, id);
     try {
         const db = MongoConnector.client().db('cart-service');
         const library = await db
         .collection(COLLECTIONS.LIBRARY)
-        .findOne({ username: username, 'contents.id': id });
-        if (library && library.contents && library.contents.length) {
-        for (let c of library.contents) {
-            if (c.id === id) {
-            c.downloaded = true;
-            break;
-            }
-        }
+        .findOne({ username: username, 'contents.id': learningObject.id });
+
+        library.libraryItem = {
+            savedOn: Date.now(),
+            savedBy: username,
+            learningObject: learningObject,
+            downloaded: true,
+        };
         db
             .collection(COLLECTIONS.LIBRARY)
             .findOneAndReplace({ username: username }, library);
-        }
         return Promise.resolve();
     } catch (e) {
         throw new Error(

--- a/src/FileManager/drivers/LearningObjectDownloads/learningObjectLibraryDownload.ts
+++ b/src/FileManager/drivers/LearningObjectDownloads/learningObjectLibraryDownload.ts
@@ -1,0 +1,36 @@
+import { COLLECTIONS } from '../../../drivers/MongoDriver';
+import { MongoConnector } from '../../../shared/MongoDB/MongoConnector';
+
+/**
+ * Appends the downloaded boolean to the document in the users library on download
+ * @param username The username of the user downloading the object
+ * @param id The learningObject ID of the learningObject being downloaded
+ */
+export async function updateObjectInLibraryForDownload(
+    username: string,
+    id: string,
+): Promise<void> {
+    console.log(username, id);
+    try {
+        const db = MongoConnector.client().db('cart-service');
+        const library = await db
+        .collection(COLLECTIONS.LIBRARY)
+        .findOne({ username: username, 'contents.id': id });
+        if (library && library.contents && library.contents.length) {
+        for (let c of library.contents) {
+            if (c.id === id) {
+            c.downloaded = true;
+            break;
+            }
+        }
+        db
+            .collection(COLLECTIONS.LIBRARY)
+            .findOneAndReplace({ username: username }, library);
+        }
+        return Promise.resolve();
+    } catch (e) {
+        throw new Error(
+        `Problem updating LearningObject in library for download. Error: ${e}`,
+        );
+    }
+}

--- a/src/FileManager/interactors/downloadBundle.ts
+++ b/src/FileManager/interactors/downloadBundle.ts
@@ -76,7 +76,7 @@ async function downloadReleasedCopy(
 ): Promise<Stream> {
   const { requester, learningObjectAuthorUsername, learningObjectId } = params;
   const learningObject = await getLearningObject(params);
-  await updateObjectInLibraryForDownload(requester.username, learningObject.id);
+  await updateObjectInLibraryForDownload(requester.username, learningObject);
 
   const fileExists = await Drivers.fileManager().hasAccess({
     authorUsername: learningObjectAuthorUsername,

--- a/src/FileManager/interactors/downloadBundle.ts
+++ b/src/FileManager/interactors/downloadBundle.ts
@@ -10,6 +10,7 @@ import { Stream } from 'stream';
 import { bundleLearningObject } from '../../LearningObjects/Publishing/Bundler/Interactor';
 import FileManagerModuleErrorMessages from './shared/errors';
 import { uploadFile } from './Interactor';
+import { updateObjectInLibraryForDownload } from '../drivers/LearningObjectDownloads/learningObjectLibraryDownload';
 
 export type DownloadBundleParams = {
   requester: UserToken;
@@ -75,6 +76,7 @@ async function downloadReleasedCopy(
 ): Promise<Stream> {
   const { requester, learningObjectAuthorUsername, learningObjectId } = params;
   const learningObject = await getLearningObject(params);
+  await updateObjectInLibraryForDownload(requester.username, learningObject.id);
 
   const fileExists = await Drivers.fileManager().hasAccess({
     authorUsername: learningObjectAuthorUsername,

--- a/src/drivers/MongoDriver.ts
+++ b/src/drivers/MongoDriver.ts
@@ -46,6 +46,7 @@ export enum COLLECTIONS {
   MULTIPART_STATUSES = 'multipart-upload-statuses',
   CHANGELOG = 'changelogs',
   SUBMISSIONS = 'submissions',
+  LIBRARY = 'carts',
 }
 
 export class MongoDriver implements DataStore {
@@ -1329,3 +1330,5 @@ export class MongoDriver implements DataStore {
     });
   }
 }
+
+

--- a/src/shared/entity/index.ts
+++ b/src/shared/entity/index.ts
@@ -7,6 +7,7 @@ import { LearningOutcome } from './learning-outcome/learning-outcome';
 import { SubmittableLearningOutcome } from './learning-outcome/submittable-learning-outcome';
 import { Collection } from './collection/collection';
 import { HierarchicalLearningObject } from './learning-object/hierarchical-learning-object';
+import { LibraryItem } from './libraryItem/libraryItem';
 
 // Exports All Interfaces
 export {
@@ -20,4 +21,5 @@ export {
   SubmittableLearningOutcome,
   StandardOutcome,
   Collection,
+  LibraryItem,
 };

--- a/src/shared/entity/libraryItem/libraryItem.ts
+++ b/src/shared/entity/libraryItem/libraryItem.ts
@@ -1,0 +1,15 @@
+import { LearningObject } from '../learning-object/learning-object';
+/**
+ * Provide abstract representation of a libraryItem
+ */
+
+export interface LibraryItem {
+    // Date item was added to library or last downloaded
+    savedOn: number;
+    // ID of the user that saved the object to their library
+    savedBy: string;
+    // Learning Object that was saved
+    learningObject: LearningObject;
+    // Optional boolean to determine if the object has been downloaded
+    downloaded?: boolean;
+}


### PR DESCRIPTION
The purpose of this PR is to move the functionality of appending the downloaded boolean on the documents in a users library to Learning Object Service. This is a temporary fix until https://app.clubhouse.io/clarkcan/story/1328/update-method-of-storage-of-download-count is completed. 

I created a "Mongo helper" function that took the existing logic from library service to append the downloaded boolean to the documents in the users library. I went with this because this is only a temporary fix and the file can be removed since the function is only being used in one place. 