### PR TITLE
Stop from sending 500 for unauthenticated 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "learning-object-service",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Learning Object Microservice.",
   "main": "app.ts",
   "scripts": {

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -165,10 +165,10 @@ export async function getInternalLearningObjectByCuid({
 
   if (!payload.length && unauthorized && !requester) {
     throw new ResourceError(`Unable to authenticate permission to view Learning Object with CUID: \`${cuid}\``, ResourceErrorReason.INVALID_ACCESS);
-  } else if (!payload.length) {
-    throw new ResourceError(`No Learning Object with CUID \`${cuid}\` and version \`${version}\` exists.`, ResourceErrorReason.NOT_FOUND);
   } else if (!payload.length && unauthorized) {
     throw new ResourceError(`User: ${requester.username} does not have permission to view Learning Object with CUID: \`${cuid}\``, ResourceErrorReason.FORBIDDEN);
+  } else if (!payload.length) {
+    throw new ResourceError(`No Learning Object with CUID \`${cuid}\` and version \`${version}\` exists.`, ResourceErrorReason.NOT_FOUND);
   }
 
   return payload;

--- a/src/LearningObjects/LearningObjectInteractor.ts
+++ b/src/LearningObjects/LearningObjectInteractor.ts
@@ -163,10 +163,12 @@ export async function getInternalLearningObjectByCuid({
     }
   });
 
-  if (!payload.length && unauthorized) {
-    throw new ResourceError(`User: ${requester.username} does not have permission to view Learning Object with CUID: \`${cuid}\``, ResourceErrorReason.FORBIDDEN);
+  if (!payload.length && unauthorized && !requester) {
+    throw new ResourceError(`Unable to authenticate permission to view Learning Object with CUID: \`${cuid}\``, ResourceErrorReason.INVALID_ACCESS);
   } else if (!payload.length) {
     throw new ResourceError(`No Learning Object with CUID \`${cuid}\` and version \`${version}\` exists.`, ResourceErrorReason.NOT_FOUND);
+  } else if (!payload.length && unauthorized) {
+    throw new ResourceError(`User: ${requester.username} does not have permission to view Learning Object with CUID: \`${cuid}\``, ResourceErrorReason.FORBIDDEN);
   }
 
   return payload;

--- a/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
+++ b/src/LearningObjects/adapters/LearningObjectRouteHandler.ts
@@ -92,7 +92,13 @@ export function initializePublic({
       }
 
       const results = await LearningObjectInteractor.getInternalLearningObjectByCuid({ dataStore, requester, authorUsername, cuid, version: version >= 0 ? version : undefined });
-
+      if (results.length > 1) {
+        if (results[0].version < results[1].version) {
+          results[0].attachRevisionUri();
+        } else if (results[1].version < results[0].version) {
+          results[1].attachRevisionUri();
+        }
+      }
       res.json(results.map(r => mapLearningObjectToSummary(r)));
     } catch (e) {
       const { code, message } = mapErrorToResponseData(e);


### PR DESCRIPTION
If the requester is undefined this route currently throws a 500 because the user can't be authenticated for unreleased learning objects. The details just spins and does not handle the error correctly. 